### PR TITLE
Migrate Sentry to @sentry/react and use Sentry.ErrorBoundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/browser": "^4.6.6",
+    "@sentry/react": "^8.0.0",
     "@vtex/react-csv-parse": "^3.0.2",
     "@vx/group": "0.0.170",
     "@vx/mock-data": "0.0.179",

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,36 +1,19 @@
-import React, { Component } from 'react';
-import * as Sentry from '@sentry/browser';
+import React from 'react';
+import * as Sentry from '@sentry/react';
 
-class ErrorBoundary extends Component {
-  constructor(props) {
-        super(props);
-        this.state = { error: null };
-    }
-
-    componentDidCatch(error, errorInfo) {
-      this.setState({ error });
-      Sentry.withScope(scope => {
-        Object.keys(errorInfo).forEach(key => {
-          scope.setExtra(key, errorInfo[key]);
-        });
-        Sentry.captureException(error);
-      });
-    }
-
-    render() {
-        if (this.state.error) {
-            //render fallback UI
-            return (
-              <div>
-                  <h1>An Error Has Occured</h1>
-                    <button onClick={() => Sentry.showReportDialog()}>Please click here to Report feedback</button>
-            </div>
-            );
-        } else {
-            //when there's not an error, render children untouched
-            return this.props.children;
-        }
-    }
-}
+const ErrorBoundary = ({ children }) => (
+  <Sentry.ErrorBoundary
+    fallback={() => (
+      <div>
+        <h1>An Error Has Occured</h1>
+        <button type="button" onClick={() => Sentry.showReportDialog()}>
+          Please click here to Report feedback
+        </button>
+      </div>
+    )}
+  >
+    {children}
+  </Sentry.ErrorBoundary>
+);
 
 export default ErrorBoundary;

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,12 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/react';
 
 Sentry.init({
-    dsn: "https://5a944e1a8e444067b60244235f6878bf@o4504362701291520.ingest.sentry.io/4504362703257600"
+    dsn: "https://5a944e1a8e444067b60244235f6878bf@o4504362701291520.ingest.sentry.io/4504362703257600",
+    integrations: [Sentry.browserTracingIntegration()],
+    tracesSampleRate: 1.0
 });
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
### Motivation

- Migrate from the legacy `@sentry/browser` package to the current React SDK to use the up-to-date React integration and tracing features.
- Update the Sentry initialization to match the newer SDK signature and enable basic performance tracing.
- Replace the app's custom error boundary logic with the SDK-provided `Sentry.ErrorBoundary` to simplify error capturing and reporting.

### Description

- Replaced `@sentry/browser` with `@sentry/react` in `package.json`.
- Updated `src/index.js` to import from `@sentry/react` and call `Sentry.init` with the existing DSN plus `integrations: [Sentry.browserTracingIntegration()]` and `tracesSampleRate: 1.0`.
- Replaced the class-based custom error boundary in `src/components/ErrorBoundary.jsx` with a functional wrapper around `Sentry.ErrorBoundary` that preserves the existing fallback UI and calls `Sentry.showReportDialog()` from the fallback.
- Verified that `ErrorBoundary` usage in the app remains unchanged and that there are no remaining `@sentry/browser` imports.

### Testing

- Ran `npm install --package-lock-only @sentry/react@^8.0.0`, which failed with a `403 Forbidden` from the npm registry so `package-lock.json` was not updated.
- Ran a code search (`rg`) to confirm there are no remaining imports of `@sentry/browser` and to locate the updated `ErrorBoundary`, which succeeded.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963444cf644832498247c0fd34a1f13)