### PR TITLE
Replace deprecated componentWillReceiveProps with props-driven components and use React 18 `createRoot`

### DIFF
--- a/src/components/AllSongsTable.jsx
+++ b/src/components/AllSongsTable.jsx
@@ -6,18 +6,6 @@ import matchSorter from 'match-sorter';
 
 class AllSongsTable extends Component {
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            songs: props.songs,
-        };
-    }
-
-    componentWillReceiveProps(nextProps) {
-        this.setState({ songs: nextProps.songs});
-    }
-
-
     addExcluded(row) {
         this.props.addExcluded(row)
     }
@@ -25,7 +13,7 @@ class AllSongsTable extends Component {
     render() {
 
         var table = <ReactTable
-            data={this.state.songs}
+            data={this.props.songs}
             filterable
             defaultFilterMethod={(filter, row) => String(row[filter.id]) === filter.value}
             columns={[

--- a/src/components/MonthChart.jsx
+++ b/src/components/MonthChart.jsx
@@ -7,21 +7,9 @@ var LineChart = require("react-chartjs").Line;
 
 class MonthChart extends Component {
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            months: props.months
-        };
-    }
-
-    componentWillReceiveProps(nextProps) {
-        this.setState({ months: nextProps.months});
-    }
-
-
     render() {
 
-        var linechart = <LineChart data={Computation.convetrData(this.state.months)} width="600" height="300" options={{ bezierCurve: true, bezierCurveTension: 0.3, pointDot: false }} />
+        var linechart = <LineChart data={Computation.convetrData(this.props.months)} width="600" height="300" options={{ bezierCurve: true, bezierCurveTension: 0.3, pointDot: false }} />
 
 
         return (<div className="box linechart">

--- a/src/components/ReasonsBox.jsx
+++ b/src/components/ReasonsBox.jsx
@@ -10,21 +10,15 @@ class ReasonsBox extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            reasons: props.reasons,
             collapse: false
         };
         this.toggle = this.toggle.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.setState({ reasons: nextProps.reasons, collapse: this.state.collapse });
-    }
-
     toggle() {
         this.setState({ 
-            collapse: !this.state.collapse,
-            reasons: this.state.reasons
-         });
+            collapse: !this.state.collapse
+        });
     }
 
     render() {
@@ -48,8 +42,8 @@ class ReasonsBox extends Component {
 
         var reasonsBoxes = [];
 
-        for (let index = 0; index < this.state.reasons.length; index++) {
-            const element = this.state.reasons[index];
+        for (let index = 0; index < this.props.reasons.length; index++) {
+            const element = this.props.reasons[index];
             if (element.key !== "" && element.key !== "QUICK_PLAY" && element.key !== "NOT_APPLICABLE") {
                 var box2 = <div className="box reason" key={element.key}>
                     <h3>{reasons[element.key]}</h3>

--- a/src/components/TopYears.jsx
+++ b/src/components/TopYears.jsx
@@ -63,17 +63,6 @@ class YearBox extends Component {
 
 class TopYears extends Component {
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            years: props.years
-        };
-    }
-
-    componentWillReceiveProps(nextProps) {
-        this.setState({ years: nextProps.years });
-    }
-
     // background-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url('https://is4-ssl.mzstatic.com/image/thumb/Music49/v4/86/75/1c/86751c2f-2ad4-d00e-0b7f-02ba9f04b007/source/300x300bb.jpg');
 
 
@@ -81,8 +70,8 @@ class TopYears extends Component {
 
         var yearsBoxes = [];
 
-        for (let index = 0; index < this.state.years.length; index++) {
-            const year = this.state.years[index];
+        for (let index = 0; index < this.props.years.length; index++) {
+            const year = this.props.years[index];
             const div = <YearBox year={year} key={year.key} />
             yearsBoxes.push(div);
 

--- a/src/components/TotalsBoxes.jsx
+++ b/src/components/TotalsBoxes.jsx
@@ -5,36 +5,18 @@ import numeral from 'numeral';
 
 class TotalsBoxes extends Component {
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            totals: props.totals,
-            day: props.day,
-            songs: props.songs,
-            artists: props.artists
-        };
-    }
-
-    componentWillReceiveProps(nextProps) {
-        this.setState({
-            totals: nextProps.totals,
-            day: nextProps.day,
-            songs: nextProps.songs,
-            artists: nextProps.artists
-        });
-    }
-
-
     render() {
+
+        const { totals, day, songs, artists } = this.props;
 
         var totalsBox = <div className="box year" key="totals">
             <div>
                 <p className="lead">You've listened to</p>
-                <h2>{Computation.convertTime(this.state.totals.totalTime)}</h2>
-                <p className="lead">of music, or {(Math.round((this.state.totals.totalTime / 1000) / 60)).toLocaleString()} minutes.</p>
+                <h2>{Computation.convertTime(totals.totalTime)}</h2>
+                <p className="lead">of music, or {(Math.round((totals.totalTime / 1000) / 60)).toLocaleString()} minutes.</p>
             </div>
             <div>
-                <h2>{numeral(this.state.totals.totalPlays).format('0,0')}</h2>
+                <h2>{numeral(totals.totalPlays).format('0,0')}</h2>
                 <p className="lead">plays</p>
             </div>
         </div>
@@ -42,9 +24,9 @@ class TotalsBoxes extends Component {
         var highestDay = <div className="box year" key="highestDay">
             <div>
                 <p className="lead">On</p>
-                <h3>{this.state.day.key}</h3>
+                <h3>{day.key}</h3>
                 <p className="lead">you listened to</p>
-                <h3>{Computation.convertTime(this.state.day.value.time)}</h3>
+                <h3>{Computation.convertTime(day.value.time)}</h3>
                 <p className="lead">of music</p>
             </div>
             <div>
@@ -54,17 +36,17 @@ class TotalsBoxes extends Component {
 
         var totalSongs = <div className="box year" key="totalSongs">
             <div>
-                <h2>{numeral(this.state.songs).format('0,0')}</h2>
+                <h2>{numeral(songs).format('0,0')}</h2>
                 <p className="lead">songs</p>
             </div>
             <div>
                 <hr className="my-2" />
-                <h2>{numeral(this.state.artists).format('0,0')}</h2>
+                <h2>{numeral(artists).format('0,0')}</h2>
                 <p className="lead">artists</p>
             </div>
             <div>
                 <hr className="my-2" />
-                <h2>{numeral(this.state.totals.totalLyrics).format('0,0')}</h2>
+                <h2>{numeral(totals.totalLyrics).format('0,0')}</h2>
                 <p className="lead">times viewed lyrics</p>
             </div>
         </div>

--- a/src/components/YearsTopSongs.jsx
+++ b/src/components/YearsTopSongs.jsx
@@ -3,24 +3,11 @@ import YearCollapse from './yearcollapse';
 
 class YearsTopSongs extends Component {
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            years: props.years,
-        };
-    }
-
-    componentWillReceiveProps(nextProps) {
-        this.setState({
-            years: nextProps.years
-        });
-    }
-
     render() {
 
         var yearsBoxes2 = [];
-        for (let index = 0; index < this.state.years.length; index++) {
-            const year = this.state.years[index];
+        for (let index = 0; index < this.props.years.length; index++) {
+            const year = this.props.years[index];
             yearsBoxes2.push(<YearCollapse year={year} key={year.key + "-full"} />);
         }
 

--- a/src/components/yearcollapse.jsx
+++ b/src/components/yearcollapse.jsx
@@ -9,20 +9,14 @@ class YearCollapse extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            year: props.year,
             collapse: false
         };
         this.toggle = this.toggle.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.setState({ year: nextProps.year, collapse: this.state.collapse });
-    }
-
     toggle() {
         this.setState({
-            collapse: !this.state.collapse,
-            year: this.state.year
+            collapse: !this.state.collapse
         });
     }
 
@@ -30,7 +24,7 @@ class YearCollapse extends Component {
 
         var songsYearBox = [];
         for (let index = 0; index < 20; index++) {
-            const element = this.state.year.value[index];
+            const element = this.props.year.value[index];
 
             if (typeof element == 'undefined') {
                 continue;
@@ -45,8 +39,8 @@ class YearCollapse extends Component {
 
         }
 
-        const div = <div className="box" key={this.state.year.key}>
-            <div> <h1>{this.state.year.key} Top Songs <Button outline color="secondary" size="sm" onClick={this.toggle}>{this.state.collapse ? 'Close' : 'Open'}</Button></h1>  </div>
+        const div = <div className="box" key={this.props.year.key}>
+            <div> <h1>{this.props.year.key} Top Songs <Button outline color="secondary" size="sm" onClick={this.toggle}>{this.state.collapse ? 'Close' : 'Open'}</Button></h1>  </div>
             <Collapse isOpen={this.state.collapse}>
                 <div className="reasons"> {songsYearBox} </div>
             </Collapse>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
@@ -9,7 +9,8 @@ Sentry.init({
     dsn: "https://5a944e1a8e444067b60244235f6878bf@o4504362701291520.ingest.sentry.io/4504362703257600"
 });
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
### Motivation
- Remove usage of the deprecated `componentWillReceiveProps` lifecycle and stop mirroring props into local state to avoid stale or duplicated state.
- Prefer deriving UI from `props` directly for components that only present data, and only keep local state for purely UI concerns like collapse toggles or fetched images.
- Upgrade the app entry point to the React 18 root API to prepare for React 18 runtime semantics.

### Description
- Removed constructors / `componentWillReceiveProps` and switched components to read data from `this.props` in `MonthChart`, `YearsTopSongs`, `TotalsBoxes`, `ReasonsBox`, `AllSongsTable`, `yearcollapse.jsx`, and `TopYears` so they no longer mirror props into state.
- Kept component-local state only for UI behavior: `collapse` toggles in `ReasonsBox` and `YearCollapse`, and `imageURL` in `YearBox` remains in state since it is fetched asynchronously.
- Updated `src/index.js` to use `createRoot` from `react-dom/client` and `root.render(<App />)` instead of `ReactDOM.render`.
- Minor updates to JSX to use destructured `props` where helpful (e.g. `TotalsBoxes` now destructures `{ totals, day, songs, artists }`).

### Testing
- No automated tests were executed as part of this change.
- Manual runtime verification was not recorded in automated logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69634445ad908324a0b42fc63018b689)