### PR TITLE
Add Vitest + Testing Library setup, Node.js >=22 engines, and basic component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,15 @@
     "test": "vitest"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^13.4.0",
     "@vitejs/plugin-react": "^4.7.0",
+    "jsdom": "^24.1.3",
     "vite": "^7.1.5",
     "vitest": "^3.2.4"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,12 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import { render, screen } from '@testing-library/react';
 import App from './App';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
+describe('App', () => {
+  it('renders the banner title on initial load', () => {
+    render(<App />);
+
+    expect(
+      screen.getByRole('heading', { name: /apple music analyser/i })
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/Banner.test.js
+++ b/src/components/Banner.test.js
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import Banner from './Banner';
+
+describe('Banner', () => {
+  it('renders the upload controls and guidance text', () => {
+    const { container } = render(<Banner dataResponseHandler={() => {}} />);
+    const filterInput = container.querySelector('#filterDate');
+    const fileInput = container.querySelector('#file');
+
+    expect(
+      screen.getByRole('heading', { name: /apple music analyser/i })
+    ).toBeInTheDocument();
+    expect(filterInput).toHaveAttribute('type', 'date');
+    expect(fileInput).toHaveAttribute('type', 'file');
+    expect(screen.getByText(/open your .* play activity\.csv/i)).toBeInTheDocument();
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,5 +11,9 @@ export default defineConfig(({ mode }) => {
     define: {
       'process.env.NODE_ENV': JSON.stringify(mode),
     },
+    test: {
+      environment: 'jsdom',
+      setupFiles: './src/setupTests.js',
+    },
   };
 });


### PR DESCRIPTION
### Motivation
- Enable running component tests with Vitest in a jsdom environment for the existing React app.
- Add Testing Library utilities to make assertions more robust and modernize tests to use RTL APIs.
- Record the minimum Node.js runtime to reduce CI/run-time mismatches by adding an `engines` constraint.
- Provide initial test coverage for the main UI surface (App and Banner) so future changes have regression protection.

### Description
- Updated `package.json` to add `@testing-library/jest-dom`, `@testing-library/react`, `jsdom` and an `engines` entry of `"node": ">=22"` and retained `vitest` as the test runner.
- Configured Vitest in `vite.config.js` with `test.environment` set to `jsdom` and `test.setupFiles` pointing to `./src/setupTests.js`.
- Added `src/setupTests.js` which imports `@testing-library/jest-dom/vitest` to provide extended matchers.
- Reworked `src/App.test.js` to use `@testing-library/react` and added `src/components/Banner.test.js` that asserts key banner controls and guidance copy are rendered.

### Testing
- Installed dependencies via `npm install` was attempted but failed with a `403 Forbidden` error while fetching `@sentry/react`, so installation did not complete.
- Because dependency installation failed, `vitest` was not executed and no test run was completed.
- Test files added/updated are `src/App.test.js`, `src/components/Banner.test.js`, and `src/setupTests.js` and are ready to run once `npm install` succeeds.
- No automated test results are available from this change due to the install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69634c4ad46483248168d2238c20ce23)