### PR TITLE
Remove `moment` dependency and replace with native Date offset helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "html2canvas": "^1.4.1",
         "jsonp": "^0.2.1",
         "match-sorter": "^6.3.4",
-        "moment": "^2.30.1",
         "numeral": "^2.0.6",
         "papaparse": "^5.4.1",
         "react": "^18.3.1",
@@ -1763,15 +1762,6 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "html2canvas": "^1.4.1",
     "jsonp": "^0.2.1",
     "match-sorter": "^6.3.4",
-    "moment": "^2.30.1",
     "numeral": "^2.0.6",
     "papaparse": "^5.4.1",
     "react": "^18.3.1",

--- a/src/components/Computation.js
+++ b/src/components/Computation.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 // import {timestamp} from 'moment-timezone';
 
 function varExists(el) { 
@@ -13,6 +12,15 @@ class Computation {
 
     static monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
+    static getOffsetDayHour(date, offsetMinutes) {
+        const offsetMilliseconds = offsetMinutes * 60 * 1000;
+        const offsetDate = new Date(date.getTime() + offsetMilliseconds);
+
+        return {
+            day: offsetDate.getUTCDay(),
+            hours: offsetDate.getUTCHours()
+        };
+    }
 
 
     static convetrData(input) {
@@ -294,9 +302,9 @@ class Computation {
                             days[dayID].time = Number(days[dayID].time) + Number(play["Play Duration Milliseconds"]);
     
                             var offset = Number(play["UTC Offset In Seconds"]) / 60;
-                            var day = moment(date).utcOffset(offset);
-                            var dayint = day.day();
-                            var hoursint = day.hours();
+                            var offsetParts = Computation.getOffsetDayHour(date, offset);
+                            var dayint = offsetParts.day;
+                            var hoursint = offsetParts.hours;
                             if (varExists(dayint) && dayint < 7 && dayint > 0 && varExists(hoursint) && varExists(heatmapData[dayint][hoursint])  && varExists(Number(heatmapData[dayint][hoursint])) && !isNaN(Number(heatmapData[dayint][hoursint])) && !isNaN(Number(play["Play Duration Milliseconds"]))) {
                                 heatmapData[dayint][hoursint] = Number(heatmapData[dayint][hoursint]) + Number(play["Play Duration Milliseconds"]);
                             }


### PR DESCRIPTION
### Motivation
- Eliminate the deprecated `moment` dependency which caused build-time warnings and dependency bloat.
- Replace a small, targeted use of `moment` (UTC offset → day/hour) with a lightweight native implementation to reduce install footprint.
- Keep the heatmap/time computations stable while removing unnecessary third-party code.
- Update lockfile and manifest to reflect the removed dependency.

### Description
- Removed `moment` from `package.json` and updated `package-lock.json` to drop the package.
- Replaced the `moment(...).utcOffset(...).day()/hours()` usage in `src/components/Computation.js` with a new `Computation.getOffsetDayHour(date, offsetMinutes)` helper that computes day/hour via native `Date` arithmetic.
- Adjusted heatmap population to use the returned `{ day, hours }` values from the helper.
- Changes committed include `package.json`, `package-lock.json`, and `src/components/Computation.js`.

### Testing
- No automated tests were run for this change.
- Manual inspection and static edits were performed to ensure the replacement is localized to the heatmap offset calculation.
- (Recommend running the project build and existing test suite / smoke tests in CI after merging.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696357ca881c8324bfd74095dd6771b0)