### PR TITLE
Play History Daily Tracks for headline play stats

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -7,7 +7,7 @@ Short index for **Cursor agents** and humans: what to read first and where full 
 | File | Read when |
 |------|-----------|
 | [rules/stack-and-workflow.md](rules/stack-and-workflow.md) | Node/Vite/Vitest scripts, `dist/` and Netlify deploy, `VITE_*` env vars, git/commit conventions, GPG/sandbox signing notes, minimal-diff style. |
-| [rules/data-pipeline-and-privacy.md](rules/data-pipeline-and-privacy.md) | `loadExport.js`, ZIP/multi-part merge, nested ZIPs, `normalizePlayRow` / `enrichArtists`, `Computation` + `computeTop` worker, fixtures vs `test-data`, privacy. |
+| [rules/data-pipeline-and-privacy.md](rules/data-pipeline-and-privacy.md) | `loadExport.js`, ZIP/multi-part merge, nested ZIPs, Play Activity + optional Daily Tracks, `normalizePlayRow` / `enrichArtists`, `Computation` + `computeTop` worker, fixtures vs `test-data`, privacy. |
 
 Cursor loads these automatically according to your Cursor rules settings; you can also `@`-mention them in chat.
 

--- a/.cursor/rules/data-pipeline-and-privacy.md
+++ b/.cursor/rules/data-pipeline-and-privacy.md
@@ -5,15 +5,15 @@ Use this rule when working on parsing, ZIP/CSV handling, play-row shape, artist 
 ## Pipeline overview (client-side only)
 
 1. **`src/data/loadExport.js`**
-   - Accepts a single CSV, a single ZIP, or **multiple ZIP parts** (Apple sometimes splits downloads). Multi-part uploads **merge ZIP entry maps** then locate Play Activity once.
+   - Accepts a single CSV, a single ZIP, or **multiple ZIP parts** (Apple sometimes splits downloads). Multi-part uploads **merge ZIP entry maps** then parse with **`parseZipEntries`**.
    - Uses **fflate** to unzip; **`expandNestedZips`** unwraps nested archives (e.g. inner `Apple_Media_Services.zip`) up to a depth cap.
-   - Finds **Apple Music Play Activity** via `isPlayActivityPath` in `src/data/schema/playActivity.js`, parses with PapaParse, validates headers/rows.
+   - Locates every **`Apple Music Play Activity.csv`** (preferring paths under `Apple_Media_Services/Apple Music Activity/`), merges rows if multiple, and optionally **`Apple Music - Play History Daily Tracks.csv`** via `isDailyTracksPath` in `src/data/schema/playHistoryDailyTracks.js`. Parses with PapaParse; validates headers/rows.
 2. **`src/data/normalizePlayRow.js`**
    - **`normalizePlayRow` / `normalizePlayRows`** — canonical per-row shape and shared constants (e.g. unknown artist handling).
 3. **`src/data/enrichArtists.js`**
    - Optional **iTunes Search API** enrichment for rows missing artist (wired from UI, e.g. `Banner.jsx`).
 4. **Heavy stats**
-   - **`src/lib/computeTopAsync.js`** — for smaller datasets runs **`Computation.calculateTop`** from **`src/components/Computation.js`** on the main thread; for larger sets uses a **module worker**: **`src/workers/computeTop.worker.js`** (Vite `worker.format: 'es'` in `vite.config.js`).
+   - **`src/lib/computeTopAsync.js`** — passes **`{ playActivityRows, dailyTrackRows }`** into **`Computation.calculateTop`** on the main thread for smaller datasets; for larger sets uses **`src/workers/computeTop.worker.js`** (Vite `worker.format: 'es'` in `vite.config.js`). When Daily Tracks rows are present, headline totals / top songs / artists / years use **`Play Count`**-weighted daily aggregation; heatmap and skip reasons still use Play Activity.
 
 Related tests live under `src/data/__tests__/` and similar.
 
@@ -27,4 +27,4 @@ Related tests live under `src/data/__tests__/` and similar.
 
 - [docs/apple-export-format.md](../../docs/apple-export-format.md) — schema, ZIP rules, nested archive behavior.
 - [docs/play-activity-columns.md](../../docs/play-activity-columns.md) — column reference.
-- Local verification scripts (see main [README.md](../../README.md)): `scripts/inspect-export-headers.mjs`, `scripts/verify-local-export.mjs`.
+- Local verification scripts (see main [README.md](../../README.md)): `scripts/inspect-export-headers.mjs`, `scripts/list-export-zip-contents.mjs`, `scripts/verify-local-export.mjs`.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ A client-side React app that analyzes your Apple Music listening history from Ap
 4. Submit the request and wait for Apple's email (often 1–7 days).
 5. Download all ZIP parts when ready.
 
-Inside the archive, the file this app uses is:
+Inside the archive, the primary file this app uses is:
 
 `Apple_Media_Services/Apple Music Activity/Apple Music Play Activity.csv`
+
+If your export includes **`Apple Music - Play History Daily Tracks.csv`** in the same folder, upload the **full ZIP** (all parts): the app uses that file for **headline play totals and top songs/artists** (summing **`Play Count`** per row when present), which usually tracks **Apple Music Replay** more closely than counting Play Activity events alone. **Charts** that need precise timestamps (hour heatmap, skip reasons, month/day series) still come from **Play Activity**, so those views may not match the headline total exactly.
 
 (Exact folder names may vary slightly by export date.)
 
@@ -24,7 +26,7 @@ Inside the archive, the file this app uses is:
 
 1. Open [the live site](https://music.samthegeek.net) or run locally (see below).
 2. Optionally set a **start date** to limit the report.
-3. Upload **Apple Music Play Activity.csv** or the **full Apple Media Services ZIP** (select all parts if Apple split the download).
+3. Upload **Apple Music Play Activity.csv** or the **full Apple Media Services ZIP** (select all parts if Apple split the download). The ZIP may also contain **Play History Daily Tracks**; the app picks it up automatically for headline play counts when present.
 4. Optionally leave **“Resolve missing artists via iTunes Search”** enabled (default) so tracks without an artist in the CSV can be labeled from Apple’s public search API (see [docs/apple-export-format.md](docs/apple-export-format.md)).
 5. Wait for parsing and stats — large exports may take a minute.
 
@@ -32,7 +34,7 @@ Inside the archive, the file this app uses is:
 
 All guides live under **[docs/](docs/)** (start at [docs/README.md](docs/README.md)):
 
-- [docs/apple-export-format.md](docs/apple-export-format.md) — schema version, ZIP + CSV behavior, nested `Apple_Media_Services.zip`, enrichment
+- [docs/apple-export-format.md](docs/apple-export-format.md) — schema versions, ZIP + CSV behavior, nested `Apple_Media_Services.zip`, optional Daily Tracks for headline totals, enrichment
 - [docs/play-activity-columns.md](docs/play-activity-columns.md) — 2026 column reference
 - [docs/roadmap.md](docs/roadmap.md) — future ideas and maintenance
 
@@ -90,10 +92,11 @@ Put your privacy export ZIP parts under `test-data/apple-media-services/` (recom
 
 ```bash
 node scripts/inspect-export-headers.mjs test-data/apple-media-services
+node scripts/list-export-zip-contents.mjs test-data/apple-media-services
 node scripts/verify-local-export.mjs test-data/apple-media-services
 ```
 
-`inspect-export-headers` lists columns and validates headers. `verify-local-export` expands nested ZIPs, parses Play Activity, and runs the same stats path as the app — useful before opening the browser.
+`inspect-export-headers` lists columns and validates headers. **`list-export-zip-contents`** lists every path inside merged ZIPs after nested expansion (use `--count` for CSV row counts). **`verify-local-export`** parses Play Activity and optional Daily Tracks and prints a Play-vs-merged totals comparison — useful before opening the browser.
 
 ## Environment variables
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,8 @@ Guides for Apple’s privacy export and this app’s behavior.
 
 | Doc | Purpose |
 |-----|---------|
-| [apple-export-format.md](apple-export-format.md) | Schema version, required columns, ZIP/CSV upload rules, nested `Apple_Media_Services.zip`, optional artist enrichment |
+| [apple-export-format.md](apple-export-format.md) | Schema versions, required columns, ZIP/CSV upload rules, nested `Apple_Media_Services.zip`, optional **Play History Daily Tracks** for headline totals, optional artist enrichment |
 | [play-activity-columns.md](play-activity-columns.md) | 2026 export column layout and why per-row artist is often missing |
 | [roadmap.md](roadmap.md) | Post-revival ideas (v2) and maintenance notes |
 
-Local scripts (from repo root): `node scripts/inspect-export-headers.mjs …`, `node scripts/verify-local-export.mjs …` — see the main [README](../README.md).
+Local scripts (from repo root): `node scripts/inspect-export-headers.mjs …`, `node scripts/list-export-zip-contents.mjs …`, `node scripts/verify-local-export.mjs …` — see the main [README](../README.md).

--- a/docs/apple-export-format.md
+++ b/docs/apple-export-format.md
@@ -1,12 +1,14 @@
 # Apple Music Play Activity export format
 
-This app reads **Apple Music Play Activity.csv** from Apple's privacy export (**Apple Media Services information**).
+This app reads **Apple Music Play Activity.csv** from Apple's privacy export (**Apple Media Services information**). When the same ZIP also contains **`Apple Music - Play History Daily Tracks.csv`**, that file drives **top songs, artists, yearly breakdowns, and headline play totals** (see below). **Play Activity** still powers **skip reasons, hour-of-week heatmap, and day/month charts** built from event timestamps.
 
 ## Schema version
 
-**Current in-app value:** `2026.2` (`SCHEMA_VERSION` in [`src/data/schema/playActivity.js`](../src/data/schema/playActivity.js)).
+**Play Activity:** `2026.2` (`SCHEMA_VERSION` in [`src/data/schema/playActivity.js`](../src/data/schema/playActivity.js)).
 
-When Apple changes column names, update `FIELD_ALIASES` in that file and bump `SCHEMA_VERSION`.
+**Play History Daily Tracks (optional):** `2026.2` (`DAILY_TRACKS_SCHEMA_VERSION` in [`src/data/schema/playHistoryDailyTracks.js`](../src/data/schema/playHistoryDailyTracks.js)).
+
+When Apple changes column names, update `FIELD_ALIASES` in the matching schema file and bump the version.
 
 ## Required columns
 
@@ -36,22 +38,38 @@ CSV headers must include the fields below (after alias resolution). `Artist Name
 
 Parsing uses Papa Parse; rows are normalized then validated. See [`loadExport.js`](../src/data/loadExport.js).
 
+### Play History Daily Tracks (optional, in the same ZIP)
+
+If present at `…/Apple Music Activity/Apple Music - Play History Daily Tracks.csv`, the app parses it and uses it for **headline metrics** that align better with **Apple Music Replay**–style “how many times did I play this?” counting than raw Play Activity rows alone:
+
+| Column | Role |
+|--------|------|
+| Date Played | Bucket by year; optional start-date filter (supports `YYYYMMDD` and ISO dates) |
+| Play Duration Milliseconds | Listening time for that daily row |
+| Track Description | Parsed into **Song Name** and **Artist Name** (same `Artist - Title` heuristics as common community tools) |
+| Play Count | **Plays attributed to that row** (often &gt; 1). Summed into totals and per-song play counts. If missing, each row counts as **1** play. |
+
+**Replay caveat:** Apple Music Replay is a product metric; the privacy export is a separate dataset. Totals should be closer to Replay when **Play Count** is present, but they may still differ.
+
+**Charts caveat:** Calendar month/day views and the hour heatmap still use **Play Activity** semantics (event stream, 8s threshold, filters, pause stitching). They may not sum to the headline **Total plays** from Daily Tracks.
+
 ## Inspecting your export
 
 After downloading from [privacy.apple.com](https://privacy.apple.com), place files under `test-data/apple-media-services/` (gitignored) and run:
 
 ```bash
 node scripts/inspect-export-headers.mjs test-data/apple-media-services
+node scripts/list-export-zip-contents.mjs test-data/apple-media-services
 ```
 
-The script lists columns, flags missing required fields for Play Activity files, and exits non-zero if the primary CSV is incompatible.
+The first script lists columns, flags missing required fields for Play Activity files, and exits non-zero if the primary CSV is incompatible. **`list-export-zip-contents`** prints every path after nested ZIP expansion (add `--count` for CSV row counts) so you can see which Apple Music CSVs are present.
 
 ## ZIP uploads
 
 The browser app accepts:
 
 - A single **Apple Music Play Activity.csv**
-- One or more **ZIP parts** from the same export request (merged in memory; see above)
+- One or more **ZIP parts** from the same export request (merged in memory; see above). The app also reads **`Apple Music - Play History Daily Tracks.csv`** from the expanded archive when present (no extra upload step).
 
 The CSV must appear at any path ending with `Apple Music Play Activity.csv` (case-insensitive).
 
@@ -66,14 +84,14 @@ Recent exports may **omit the `Artist Name` column** entirely (e.g. 143 columns,
 
 Top songs and play counts stay accurate; artist charts improve when **optional enrichment** runs.
 
-### Optional artist resolution
+### Optional artist resolution (iTunes Search)
 
 The **“Resolve missing artists via iTunes Search”** checkbox in the upload banner (on by default) calls [`enrichArtists`](../src/data/enrichArtists.js), which:
 
 1. Builds a frequency map of rows whose artist is still `Unknown Artist`
 2. Takes the **500** most-played unique `(Song Name, Album Name)` keys (configurable via `maxLookups`)
 3. For each key not already in cache, calls the public **iTunes Search API** (with ~**120 ms** delay between network lookups)
-4. Persists results in **`localStorage`** (see `artistCache.js`) and rewrites matching rows before stats
+4. Persists results in **`localStorage`** (see `artistCache.js`) and rewrites matching **Play Activity** rows before stats (Daily Tracks artists come from **Track Description** when that file is used for totals)
 
 Unmatched or failed lookups stay **Unknown Artist**. Results are best-effort (search ambiguity, rate limits). See [play-activity-columns.md](play-activity-columns.md) for why the CSV often lacks a per-track artist.
 

--- a/docs/play-activity-columns.md
+++ b/docs/play-activity-columns.md
@@ -2,6 +2,8 @@
 
 Based on the January 2026 **Apple Media Services** privacy export (~57k rows, **143 columns**). Legacy exports also included a dedicated **`Artist Name`** column; this one does not.
 
+**Related file:** **`Apple Music - Play History Daily Tracks.csv`** (same export folder) includes **`Track Description`** (artist/title text) and **`Play Count`**; the app uses it for headline play totals when you upload the full ZIP. See [apple-export-format.md](apple-export-format.md).
+
 ## Where is the artist?
 
 | Field | Role | Useful for track artist? |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,13 +12,13 @@ The `database` branch prototyped an in-browser SQL panel using **alasql** and **
 
 ### Multi-CSV bundle
 
-Apple's export now includes several Apple Music files, for example:
+Apple's export includes several Apple Music files, for example:
 
-- Apple Music Play Activity.csv (supported today)
-- Apple Music - Play History Daily Tracks.csv
+- Apple Music Play Activity.csv (supported — event-level charts)
+- Apple Music - Play History Daily Tracks.csv (**supported** when inside the same ZIP — headline totals / top lists; see `loadExport.js` and `playHistoryDailyTracks.js`)
 - Apple Music - Recently Played Tracks.csv
 
-**Proposal:** Let users pick a primary source or merge complementary fields (e.g. impressions + plays).
+**Future:** Let users pick a primary source or merge complementary fields beyond the current Play Activity + Daily Tracks split.
 
 ### Artist enrichment v2
 

--- a/fixtures/play-activity/daily-tracks-sample.csv
+++ b/fixtures/play-activity/daily-tracks-sample.csv
@@ -1,0 +1,4 @@
+Date Played,Play Duration Milliseconds,Track Description,Play Count
+2024-06-15,180000,Test Artist - Test Song Alpha,2
+2024-06-16,120000,Test Artist - Test Song Alpha,1
+2024-06-17,90000,Beta Band - Other Track,1

--- a/scripts/list-export-zip-contents.mjs
+++ b/scripts/list-export-zip-contents.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * List all paths inside Apple Media Services ZIPs after nested expansion (same as the app).
+ * Optionally print CSV header lines and row counts.
+ *
+ * Usage:
+ *   node scripts/list-export-zip-contents.mjs [dir-with-zips]
+ *   node scripts/list-export-zip-contents.mjs --count [dir]
+ *
+ * Default dir: test-data (ZIPs directly in folder; not recursive subdirs).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { unzipSync } from 'fflate';
+import { expandNestedZips } from '../src/data/loadExport.js';
+import { isPlayActivityPath } from '../src/data/schema/playActivity.js';
+import { isDailyTracksPath } from '../src/data/schema/playHistoryDailyTracks.js';
+
+const args = process.argv.slice(2);
+const wantCount = args.includes('--count');
+const dirs = args.filter((a) => a !== '--count');
+const dir = dirs[0] ?? 'test-data';
+
+function findZips(folder) {
+  const out = [];
+  for (const name of readdirSync(folder)) {
+    const path = join(folder, name);
+    if (statSync(path).isFile() && name.toLowerCase().endsWith('.zip')) {
+      out.push(path);
+    }
+  }
+  return out.sort();
+}
+
+function countCsvRows(data) {
+  const text = new TextDecoder('utf-8').decode(data);
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  return Math.max(0, lines.length - 1);
+}
+
+const zips = findZips(dir);
+if (zips.length === 0) {
+  console.error(`No .zip files in ${dir}`);
+  process.exit(1);
+}
+
+let merged = {};
+for (const z of zips) {
+  const buf = readFileSync(z);
+  merged = { ...merged, ...expandNestedZips(unzipSync(new Uint8Array(buf))) };
+}
+
+const paths = Object.keys(merged).sort();
+console.log(`ZIP parts: ${zips.length}`);
+console.log(`Expanded entries: ${paths.length}\n`);
+
+for (const p of paths) {
+  if (p.endsWith('/')) {
+    console.log(`[dir] ${p}`);
+    continue;
+  }
+  const data = merged[p];
+  const size = data?.length ?? 0;
+  const flags = [];
+  if (isPlayActivityPath(p)) flags.push('PLAY_ACTIVITY');
+  if (isDailyTracksPath(p)) flags.push('DAILY_TRACKS');
+  const tag = flags.length ? ` [${flags.join(', ')}]` : '';
+
+  if (p.toLowerCase().endsWith('.csv')) {
+    const peek = new TextDecoder('utf-8').decode(data.slice(0, 4096));
+    const header = peek.split(/\r?\n/)[0] ?? '';
+    let line = `${size.toLocaleString()} bytes${tag}\n  ${p}\n  header: ${header.slice(0, 200)}${header.length > 200 ? '…' : ''}`;
+    if (wantCount) {
+      line += `\n  rows (excl. header): ${countCsvRows(data).toLocaleString()}`;
+    }
+    console.log(line);
+  } else {
+    console.log(`${size.toLocaleString()} bytes${tag}\n  ${p}`);
+  }
+  console.log('');
+}

--- a/scripts/verify-local-export.mjs
+++ b/scripts/verify-local-export.mjs
@@ -5,10 +5,10 @@
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
-import { expandNestedZips } from '../src/data/loadExport.js';
+import { expandNestedZips, parseZipEntries } from '../src/data/loadExport.js';
 import { unzipSync } from 'fflate';
-import { isPlayActivityPath, validateHeaders, SCHEMA_VERSION } from '../src/data/schema/playActivity.js';
-import { parsePlayActivityCsv } from '../src/data/loadExport.js';
+import { SCHEMA_VERSION } from '../src/data/schema/playActivity.js';
+import { DAILY_TRACKS_SCHEMA_VERSION } from '../src/data/schema/playHistoryDailyTracks.js';
 import Computation from '../src/components/Computation.js';
 
 const dir = process.argv[2] ?? 'test-data';
@@ -30,7 +30,8 @@ if (zips.length === 0) {
   process.exit(1);
 }
 
-console.log(`Schema ${SCHEMA_VERSION}`);
+console.log(`Play Activity schema ${SCHEMA_VERSION}`);
+console.log(`Daily Tracks schema ${DAILY_TRACKS_SCHEMA_VERSION}`);
 console.log(`ZIP parts: ${zips.length}\n`);
 
 let merged = {};
@@ -40,36 +41,40 @@ for (const z of zips) {
   merged = { ...merged, ...expandNestedZips(unzipSync(new Uint8Array(buf))) };
 }
 
-const playPath = Object.keys(merged).find((p) => isPlayActivityPath(p));
-if (!playPath) {
-  console.error('Play Activity CSV not found after expanding nested ZIPs.');
+let playActivityRows;
+let dailyTrackRows;
+let sourcePaths;
+try {
+  ({ playActivityRows, dailyTrackRows, sourcePaths } = await parseZipEntries(merged));
+} catch (e) {
+  console.error(e instanceof Error ? e.message : e);
   process.exit(1);
 }
 
-const csvText = new TextDecoder('utf-8').decode(merged[playPath]);
-const headerLine = csvText.split(/\r?\n/)[0];
-const headers = headerLine.split(',').map((h) => h.trim().replace(/^"|"$/g, ''));
-const { missing, warnings } = validateHeaders(headers);
-
-console.log(`\nPlay Activity: ${playPath}`);
-console.log(`Columns: ${headers.length}`);
-if (warnings.length) warnings.forEach((w) => console.warn(`Warning: ${w}`));
-if (missing.length) {
-  console.error(`Missing columns: ${missing.join(', ')}`);
-  process.exit(1);
+console.log(`\nPlay Activity: ${sourcePaths.playActivity}`);
+console.log(`Play Activity rows: ${playActivityRows.length.toLocaleString()}`);
+if (sourcePaths.dailyTracks) {
+  console.log(`Daily Tracks: ${sourcePaths.dailyTracks}`);
+  console.log(`Daily Tracks rows: ${(dailyTrackRows?.length ?? 0).toLocaleString()}`);
+} else {
+  console.log('Daily Tracks: (not present or invalid in export)');
 }
 
-console.log('Parsing CSV…');
-const rows = await parsePlayActivityCsv(csvText);
-console.log(`Rows: ${rows.length.toLocaleString()}`);
-console.log(`Sample artist: ${rows[0]?.['Artist Name']}`);
-
-console.log('Computing stats…');
-const results = await new Promise((resolve) => {
-  Computation.calculateTop(rows, [], resolve);
+const activityOnly = await new Promise((resolve) => {
+  Computation.calculateTop(playActivityRows, [], resolve, { dailyTrackRows: null });
 });
 
-console.log(`\nTop song: ${results.filteredSongs[0]?.key ?? '(none)'}`);
-console.log(`Total plays: ${results.totals.totalPlays.toLocaleString()}`);
-console.log(`Unique songs: ${results.songs.length.toLocaleString()}`);
+const mergedStats = await new Promise((resolve) => {
+  Computation.calculateTop(playActivityRows, [], resolve, { dailyTrackRows });
+});
+
+console.log('\n--- Compare (Play Activity only vs merged with Daily Tracks) ---');
+console.log(
+  `Total plays (activity semantics): ${activityOnly.totals.totalPlays.toLocaleString()} | merged UI totals: ${mergedStats.totals.totalPlays.toLocaleString()}`,
+);
+console.log(
+  `Total time ms (activity): ${activityOnly.totals.totalTime.toLocaleString()} | merged: ${mergedStats.totals.totalTime.toLocaleString()}`,
+);
+console.log(`Top song (merged): ${mergedStats.filteredSongs[0]?.key ?? '(none)'}`);
+console.log(`Unique songs (merged): ${mergedStats.songs.length.toLocaleString()}`);
 console.log('\nOK — export is compatible.');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,13 @@ function App() {
 
   let appToLoad;
 
-  if (data.length > 0) {
+  const hasReport =
+    data &&
+    typeof data === 'object' &&
+    Array.isArray(data.playActivityRows) &&
+    data.playActivityRows.length > 0;
+
+  if (hasReport) {
     appToLoad = (
       <Suspense
         fallback={

--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -1,5 +1,9 @@
 import React, { useState, useId } from 'react';
-import { loadExport, filterRowsByStartDate } from '../data/loadExport.js';
+import {
+  loadExport,
+  filterRowsByStartDate,
+  filterDailyTracksByStartDate,
+} from '../data/loadExport.js';
 import { enrichArtists } from '../data/enrichArtists.js';
 
 function Banner({ dataResponseHandler, onError, onProgress }) {
@@ -22,7 +26,7 @@ function Banner({ dataResponseHandler, onError, onProgress }) {
     setStatusText('Reading export…');
 
     try {
-      const { rows, sourcePath } = await loadExport(files, (progress) => {
+      const { playActivityRows, dailyTrackRows, sourcePaths } = await loadExport(files, (progress) => {
         const labels = {
           reading: 'Reading file…',
           unzipping: 'Unzipping archive…',
@@ -34,10 +38,17 @@ function Banner({ dataResponseHandler, onError, onProgress }) {
         onProgress?.(progress);
       });
 
-      setStatusText(`Loaded ${sourcePath}. Preparing report…`);
+      const pathSummary = [sourcePaths.playActivity, sourcePaths.dailyTracks]
+        .filter(Boolean)
+        .join(' · ');
+      setStatusText(`Loaded ${pathSummary}. Preparing report…`);
 
       const filterDate = document.getElementById(filterDateId)?.value ?? '';
-      let filtered = filterRowsByStartDate(rows, filterDate);
+      let filtered = filterRowsByStartDate(playActivityRows, filterDate);
+      const filteredDaily =
+        dailyTrackRows && dailyTrackRows.length > 0
+          ? filterDailyTracksByStartDate(dailyTrackRows, filterDate)
+          : null;
 
       if (resolveArtists) {
         setStatusText('Resolving missing artists (iTunes Search)…');
@@ -51,8 +62,18 @@ function Banner({ dataResponseHandler, onError, onProgress }) {
         });
       }
 
-      dataResponseHandler(filtered);
-      setStatusText(`Loaded ${filtered.length.toLocaleString()} plays.`);
+      dataResponseHandler({
+        playActivityRows: filtered,
+        dailyTrackRows: filteredDaily,
+        sourcePaths,
+      });
+      const dailyNote =
+        filteredDaily && filteredDaily.length > 0
+          ? ` · ${filteredDaily.length.toLocaleString()} daily track rows (used for top plays when present)`
+          : '';
+      setStatusText(
+        `Loaded ${filtered.length.toLocaleString()} play events${dailyNote}.`,
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load export.';
       onError?.(message);

--- a/src/components/Computation.js
+++ b/src/components/Computation.js
@@ -107,12 +107,14 @@ class Computation {
         return result
     }
 
+    /**
+     * Stitch pause segments without requiring Artist Name to match (enrichment can change artist mid-session).
+     */
     static isSamePlay(play, previousPlay) {
         if (previousPlay != null &&
             Computation.isPlay(previousPlay) && 
             Computation.isPlay(play) &&
             previousPlay["Song Name"] === play["Song Name"] &&
-            previousPlay["Artist Name"] === play["Artist Name"] &&
             previousPlay["End Position In Milliseconds"] === play["Start Position In Milliseconds"] &&
             previousPlay["End Reason Type"] === "PLAYBACK_MANUALLY_PAUSED") {
             return true;
@@ -126,7 +128,6 @@ class Computation {
             Computation.isPlay(nextPlay) && 
             Computation.isPlay(play) &&
             nextPlay["Song Name"] === play["Song Name"] &&
-            nextPlay["Artist Name"] === play["Artist Name"] &&
             play["End Position In Milliseconds"] === nextPlay["Start Position In Milliseconds"] &&
             play["End Reason Type"] === "PLAYBACK_MANUALLY_PAUSED") {
             return true;
@@ -143,9 +144,208 @@ class Computation {
         }
     }
 
-    
+    /**
+     * @param {Record<string, string>[]} data
+     * @returns {Record<string, string>[]}
+     */
+    static sortPlayActivityByEventEnd(data) {
+        if (!data || data.length === 0) {
+            return data;
+        }
+        return [...data].sort((a, b) => {
+            const ta = String(a["Event End Timestamp"] ?? "");
+            const tb = String(b["Event End Timestamp"] ?? "");
+            return ta.localeCompare(tb);
+        });
+    }
 
-    static calculateTop(data, excludedSongs, callback) {
+    /**
+     * @param {string} [s]
+     * @returns {number | null}
+     */
+    static yearFromDatePlayed(s) {
+        if (!s || !String(s).trim()) {
+            return null;
+        }
+        var raw = String(s).trim();
+        if (/^\d{8}$/.test(raw)) {
+            return Number(raw.slice(0, 4));
+        }
+        var t = Date.parse(raw);
+        if (!Number.isNaN(t)) {
+            return new Date(t).getFullYear();
+        }
+        if (/^\d{4}/.test(raw)) {
+            return Number(raw.slice(0, 4));
+        }
+        return null;
+    }
+
+    /**
+     * Top songs / artists / totals / yearly buckets from Play History Daily Tracks (one row ≈ one play).
+     * @param {Record<string, string>[]} dailyRows
+     * @param {string[]} excludedSongs
+     * @param {number} today
+     */
+    static aggregateDailyTrackStats(dailyRows, excludedSongs, today) {
+        var songs = {};
+        var artists = {};
+        var yearSongs = {};
+        var thisYear = {
+            totalPlays: 0,
+            totalTime: 0,
+            year: today,
+            artists: {}
+        };
+        var totals = {
+            totalPlays: 0,
+            totalTime: 0,
+            totalLyrics: 0
+        };
+
+        for (var i = 0; i < dailyRows.length; i++) {
+            var row = dailyRows[i];
+            var song = row["Song Name"] != null ? String(row["Song Name"]).trim() : "";
+            var artist = row["Artist Name"] != null && String(row["Artist Name"]).trim().length > 0
+                ? String(row["Artist Name"]).trim()
+                : "Unknown Artist";
+            var dur = Number(row["Play Duration Milliseconds"]);
+            var datePlayed = row["Date Played"] != null ? String(row["Date Played"]).trim() : "";
+            var playCountRaw = Number(row["Play Count"]);
+            var playCount = Number.isFinite(playCountRaw) && playCountRaw >= 1 ? Math.floor(playCountRaw) : 1;
+
+            if (!song || !Number.isFinite(dur) || dur <= 0) {
+                continue;
+            }
+
+            var uniqueID = "'" + song + "' by " + artist;
+            var excluded = excludedSongs.includes(uniqueID);
+
+            if (songs[uniqueID] == null) {
+                songs[uniqueID] = {
+                    plays: 0,
+                    time: 0,
+                    name: song,
+                    artist: artist,
+                    missedTime: 0,
+                    excluded: excluded
+                };
+            }
+
+            songs[uniqueID].plays = songs[uniqueID].plays + playCount;
+            songs[uniqueID].time = Number(songs[uniqueID].time) + dur;
+
+            if (!excluded) {
+                totals.totalPlays = totals.totalPlays + playCount;
+                totals.totalTime = Number(totals.totalTime) + dur;
+
+                if (artists[artist] == null) {
+                    artists[artist] = {
+                        plays: 0,
+                        time: 0,
+                        missedTime: 0
+                    };
+                }
+                artists[artist].plays = artists[artist].plays + playCount;
+                artists[artist].time = Number(artists[artist].time) + dur;
+
+                var yearID = Computation.yearFromDatePlayed(datePlayed);
+                if (yearID != null) {
+                    if (yearSongs[yearID] == null) {
+                        yearSongs[yearID] = {};
+                    }
+                    if (yearSongs[yearID][uniqueID] == null) {
+                        yearSongs[yearID][uniqueID] = {
+                            plays: 0,
+                            time: 0,
+                            name: song,
+                            artist: artist,
+                            missedTime: 0
+                        };
+                    }
+                    yearSongs[yearID][uniqueID].plays = yearSongs[yearID][uniqueID].plays + playCount;
+                    yearSongs[yearID][uniqueID].time = Number(yearSongs[yearID][uniqueID].time) + dur;
+
+                    if (today === yearID) {
+                        if (thisYear.artists[artist] == null) {
+                            thisYear.artists[artist] = {
+                                plays: 0,
+                                time: 0,
+                                missedTime: 0
+                            };
+                        }
+                        thisYear.totalPlays = thisYear.totalPlays + playCount;
+                        thisYear.totalTime = Number(thisYear.totalTime) + dur;
+                        thisYear.artists[artist].plays = thisYear.artists[artist].plays + playCount;
+                        thisYear.artists[artist].time = Number(thisYear.artists[artist].time) + dur;
+                    }
+                }
+            }
+        }
+
+        var result = Computation.convertObjectToArray(songs);
+        result = result.sort(function (a, b) {
+            return b.value.time - a.value.time;
+        });
+
+        var filteredSongs = [];
+        for (var fi = 0; fi < result.length; fi++) {
+            if (!result[fi].value.excluded) {
+                filteredSongs.push(result[fi]);
+            }
+        }
+
+        var yearresult = Computation.convertObjectToArray(yearSongs);
+        for (var yi = 0; yi < yearresult.length; yi++) {
+            yearresult[yi].value = Computation.convertObjectToArray(yearresult[yi].value);
+            yearresult[yi].value = yearresult[yi].value.sort(function (a, b) {
+                return b.value.time - a.value.time;
+            });
+        }
+
+        var thisYearArtsistsResult = Computation.convertObjectToArray(thisYear.artists);
+        thisYearArtsistsResult = thisYearArtsistsResult.sort(function (a, b) {
+            return b.value.time - a.value.time;
+        });
+
+        var thisYearSongs = yearSongs[today] != null ? Computation.convertObjectToArray(yearSongs[today]) : [];
+        thisYearSongs = thisYearSongs.sort(function (a, b) {
+            return b.value.time - a.value.time;
+        });
+
+        var thisYearResult = {
+            totalPlays: thisYear.totalPlays,
+            totalTime: thisYear.totalTime,
+            year: today,
+            artists: thisYearArtsistsResult,
+            songs: thisYearSongs
+        };
+
+        var artistsResults = Computation.convertObjectToArray(artists);
+        artistsResults = artistsResults.sort(function (a, b) {
+            return b.value.time - a.value.time;
+        });
+
+        return {
+            songs: result,
+            filteredSongs: filteredSongs,
+            years: yearresult,
+            thisYear: thisYearResult,
+            artists: artistsResults,
+            totals: totals
+        };
+    }
+
+    /**
+     * @param {Record<string, string>[]} data
+     * @param {string[]} excludedSongs
+     * @param {function(object): void} callback
+     * @param {{ dailyTrackRows?: Record<string, string>[] | null }} [options]
+     */
+    static calculateTop(data, excludedSongs, callback, options) {
+        options = options || {};
+
+        data = Computation.sortPlayActivityByEventEnd(data);
 
         let today = new Date().getFullYear();
         if (new Date().getMonth() < 5) {
@@ -421,7 +621,7 @@ class Computation {
             return b.value.time - a.value.time;
         });
 
-        var thisYearSongs = Computation.convertObjectToArray(yearSongs[today]);
+        var thisYearSongs = Computation.convertObjectToArray(yearSongs[today] || {});
         thisYearSongs = thisYearSongs.sort(function (a, b) {
             return b.value.time - a.value.time;
         });
@@ -464,8 +664,21 @@ class Computation {
             thisYear: thisYearResult
         }
 
+        var dailyRows = options.dailyTrackRows;
+        if (dailyRows != null && dailyRows.length > 0) {
+            var dailyStats = Computation.aggregateDailyTrackStats(dailyRows, excludedSongs, today);
+            returnVal.songs = dailyStats.songs;
+            returnVal.filteredSongs = dailyStats.filteredSongs;
+            returnVal.years = dailyStats.years;
+            returnVal.thisYear = dailyStats.thisYear;
+            returnVal.artists = dailyStats.artists;
+            returnVal.totals = dailyStats.totals;
+        }
 
         callback(returnVal);
+        console.log(returnVal);
+
+        // return 
     }
 }
 

--- a/src/components/Computation.js
+++ b/src/components/Computation.js
@@ -1,5 +1,7 @@
 // import {timestamp} from 'moment-timezone';
 
+import { UNKNOWN_ARTIST } from '../data/normalizePlayRow.js';
+
 function varExists(el) { 
     if (el !== null && typeof el !== "undefined" ) { 
       return true; 
@@ -9,6 +11,18 @@ function varExists(el) {
 }
 
 class Computation {
+
+    /**
+     * Apple exports sometimes emit Track Description "N/A" → unknown artist; exclude from all stats.
+     * @param {string} [songName]
+     * @param {string} [artistName]
+     * @returns {boolean}
+     */
+    static isExcludedPlaceholderListeningRow(songName, artistName) {
+        var song = String(songName ?? '').trim();
+        var artist = String(artistName ?? '').trim() || UNKNOWN_ARTIST;
+        return song === 'N/A' && artist === UNKNOWN_ARTIST;
+    }
 
     static monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
@@ -215,6 +229,10 @@ class Computation {
             var playCount = Number.isFinite(playCountRaw) && playCountRaw >= 1 ? Math.floor(playCountRaw) : 1;
 
             if (!song || !Number.isFinite(dur) || dur <= 0) {
+                continue;
+            }
+
+            if (Computation.isExcludedPlaceholderListeningRow(song, artist)) {
                 continue;
             }
 
@@ -427,7 +445,9 @@ class Computation {
         for (let index = 0; index < data.length; index++) {
             const play = data[index];
 
-            
+            if (Computation.isExcludedPlaceholderListeningRow(play["Song Name"], play["Artist Name"])) {
+                continue;
+            }
 
             if (varExists(play["Song Name"]) && varExists(play["Artist Name"]) && varExists(play["Play Duration Milliseconds"]) && varExists(play["Media Duration In Milliseconds"]) && varExists(play["Event End Timestamp"]) && varExists(play["UTC Offset In Seconds"])) {
                 reasons[play["End Reason Type"]] = reasons[play["End Reason Type"]] + 1;

--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -34,7 +34,14 @@ class Results extends Component {
   async runComputation(data, excludedSongs) {
     this.setState({ computeStatus: 'Computing your stats…', computeError: null, songs: null });
     try {
-      const results = await computeTopAsync(data, excludedSongs);
+      const payload =
+        data && typeof data === 'object' && !Array.isArray(data) && data.playActivityRows
+          ? {
+              playActivityRows: data.playActivityRows,
+              dailyTrackRows: data.dailyTrackRows ?? null,
+            }
+          : { playActivityRows: Array.isArray(data) ? data : [], dailyTrackRows: null };
+      const results = await computeTopAsync(payload, excludedSongs);
       this.setState({
         songs: results.songs,
         days: results.days,

--- a/src/data/__tests__/loadExport.test.js
+++ b/src/data/__tests__/loadExport.test.js
@@ -3,13 +3,69 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import { zipSync, unzipSync } from 'fflate';
-import { parsePlayActivityCsv, expandNestedZips } from '../loadExport.js';
+import {
+  parsePlayActivityCsv,
+  expandNestedZips,
+  parseZipEntries,
+  scoreAppleMusicActivityPath,
+} from '../loadExport.js';
 import { isPlayActivityPath } from '../schema/playActivity.js';
+import { isDailyTracksPath } from '../schema/playHistoryDailyTracks.js';
+import { parseDailyTracksCsv } from '../parseDailyTracksCsv.js';
+import Computation from '../../components/Computation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturePath = join(__dirname, '../../../fixtures/play-activity/sample-rows.csv');
+const dailyFixturePath = join(__dirname, '../../../fixtures/play-activity/daily-tracks-sample.csv');
 
 describe('loadExport helpers', () => {
+  it('prefers canonical Apple_Media_Services activity path score', () => {
+    const a = scoreAppleMusicActivityPath('Apple_Media_Services/Apple Music Activity/Apple Music Play Activity.csv');
+    const b = scoreAppleMusicActivityPath('tmp/Apple Music Play Activity.csv');
+    expect(a).toBeGreaterThan(b);
+  });
+
+  it('parses sample daily tracks fixture', async () => {
+    const text = readFileSync(dailyFixturePath, 'utf8');
+    const rows = await parseDailyTracksCsv(text);
+    expect(rows.length).toBe(3);
+    expect(rows[0]['Artist Name']).toBe('Test Artist');
+    expect(rows[0]['Song Name']).toBe('Test Song Alpha');
+  });
+
+  it('parseZipEntries loads play activity and daily tracks from nested zip', async () => {
+    const playCsv = readFileSync(fixturePath, 'utf8');
+    const dailyCsv = readFileSync(dailyFixturePath, 'utf8');
+    const inner = zipSync({
+      'Apple_Media_Services/Apple Music Activity/Apple Music Play Activity.csv': new TextEncoder().encode(
+        playCsv,
+      ),
+      'Apple_Media_Services/Apple Music Activity/Apple Music - Play History Daily Tracks.csv':
+        new TextEncoder().encode(dailyCsv),
+    });
+    const outer = zipSync({
+      'Apple_Media_Services.zip': inner,
+    });
+    const merged = expandNestedZips(unzipSync(outer));
+    const { playActivityRows, dailyTrackRows, sourcePaths } = await parseZipEntries(merged);
+    expect(playActivityRows.length).toBe(3);
+    expect(dailyTrackRows?.length).toBe(3);
+    expect(sourcePaths.dailyTracks).toContain('Play History Daily Tracks');
+  });
+  it('uses daily tracks for headline totals when provided', async () => {
+    const playRows = await parsePlayActivityCsv(readFileSync(fixturePath, 'utf8'));
+    const dailyRows = await parseDailyTracksCsv(readFileSync(dailyFixturePath, 'utf8'));
+    const merged = await new Promise((resolve) => {
+      Computation.calculateTop(playRows, [], resolve, { dailyTrackRows: dailyRows });
+    });
+    expect(merged.totals.totalPlays).toBe(4);
+  });
+
+  it('recognizes daily tracks file paths', () => {
+    expect(isDailyTracksPath('Apple Music Activity/Apple Music - Play History Daily Tracks.csv')).toBe(true);
+    expect(isDailyTracksPath('Apple Music Play Activity.csv')).toBe(false);
+  });
+
   it('recognizes play activity file paths', () => {
     expect(isPlayActivityPath('Apple Music Activity/Apple Music Play Activity.csv')).toBe(true);
     expect(isPlayActivityPath('other.csv')).toBe(false);

--- a/src/data/__tests__/parseTrackDescription.test.js
+++ b/src/data/__tests__/parseTrackDescription.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { parseTrackDescription } from '../parseTrackDescription.js';
+
+describe('parseTrackDescription', () => {
+  it('parses artist and title for two segments', () => {
+    const r = parseTrackDescription('CHVRCHES - The Mother We Share');
+    expect(r.artist).toBe('CHVRCHES');
+    expect(r.song).toBe('The Mother We Share');
+    expect(r.album).toBe('');
+  });
+
+  it('parses three-part as artist, album, title', () => {
+    const r = parseTrackDescription('Artist Name - Album Title - Song Title');
+    expect(r.artist).toBe('Artist Name');
+    expect(r.album).toBe('Album Title');
+    expect(r.song).toBe('Song Title');
+  });
+
+  it('uses unknown artist for single segment', () => {
+    const r = parseTrackDescription('Instrumental');
+    expect(r.artist).toBe('Unknown Artist');
+    expect(r.song).toBe('Instrumental');
+  });
+});

--- a/src/data/loadExport.js
+++ b/src/data/loadExport.js
@@ -1,12 +1,18 @@
 import Papa from 'papaparse';
 import { unzipSync } from 'fflate';
 import { isPlayActivityPath } from './schema/playActivity.js';
+import { isDailyTracksPath } from './schema/playHistoryDailyTracks.js';
 import { normalizePlayRows } from './normalizePlayRow.js';
 import { validatePlayActivityHeaders, validatePlayActivityRows } from './validateExport.js';
+import {
+  parseDailyTracksCsv,
+  validateDailyTracksRowsFromHeaders,
+  validateDailyTracksRows,
+} from './parseDailyTracksCsv.js';
 
 /**
  * @param {ArrayBuffer} buffer
- * @returns {Map<string, Uint8Array>}
+ * @returns {Record<string, Uint8Array>}
  */
 function unzipToEntries(buffer) {
   const bytes = new Uint8Array(buffer);
@@ -47,24 +53,62 @@ export function expandNestedZips(entries, depth = 0) {
 }
 
 /**
+ * Prefer canonical Apple_Media_Services → Apple Music Activity paths when multiple CSVs exist.
+ * @param {string} p
+ * @returns {number}
+ */
+export function scoreAppleMusicActivityPath(p) {
+  const lower = p.replace(/\\/g, '/').toLowerCase();
+  if (lower.includes('apple_media_services') && lower.includes('apple music activity')) {
+    return 2;
+  }
+  if (lower.includes('apple music activity')) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * @param {Record<string, Uint8Array>} entries
+ * @returns {string[]}
+ */
+export function findAllPlayActivityPaths(entries) {
+  const paths = Object.keys(entries).filter((p) => isPlayActivityPath(p) && !p.endsWith('/'));
+  return paths.sort((a, b) => scoreAppleMusicActivityPath(b) - scoreAppleMusicActivityPath(a));
+}
+
+/**
+ * @param {Record<string, Uint8Array>} entries
+ * @returns {{ path: string, data: Uint8Array } | null}
+ */
+export function findDailyTracksInZip(entries) {
+  const paths = Object.keys(entries).filter((p) => isDailyTracksPath(p) && !p.endsWith('/'));
+  if (paths.length === 0) {
+    return null;
+  }
+  paths.sort((a, b) => scoreAppleMusicActivityPath(b) - scoreAppleMusicActivityPath(a));
+  const path = paths[0];
+  return { path, data: entries[path] };
+}
+
+/**
+ * @param {Record<string, Uint8Array>} entries
+ * @returns {{ path: string, data: Uint8Array } | null}
+ */
+function findFirstPlayActivityInZip(entries) {
+  const paths = findAllPlayActivityPaths(entries);
+  if (paths.length === 0) {
+    return null;
+  }
+  return { path: paths[0], data: entries[paths[0]] };
+}
+
+/**
  * @param {ArrayBuffer} buffer
  * @returns {Record<string, Uint8Array>}
  */
 function unzipAndExpand(buffer) {
   return expandNestedZips(unzipToEntries(buffer));
-}
-
-/**
- * @param {Map<string, Uint8Array> | Record<string, Uint8Array>} entries
- * @returns {{ path: string, data: Uint8Array } | null}
- */
-function findPlayActivityInZip(entries) {
-  const paths = Object.keys(entries);
-  const match = paths.find((p) => isPlayActivityPath(p) && !p.endsWith('/'));
-  if (!match) {
-    return null;
-  }
-  return { path: match, data: entries[match] };
 }
 
 /**
@@ -105,9 +149,83 @@ export function parsePlayActivityCsv(csvText, onProgress) {
 }
 
 /**
+ * @param {Record<string, Uint8Array>} entries
+ * @param {string[]} paths
+ * @param {(progress: { phase: string, percent?: number }) => void} [onProgress]
+ * @returns {Promise<Record<string, string>[]>}
+ */
+async function parseMergedPlayActivityFromZip(entries, paths, onProgress) {
+  let merged = [];
+  for (let i = 0; i < paths.length; i++) {
+    const csvText = decodeUtf8(entries[paths[i]]);
+    const rows = await parsePlayActivityCsv(csvText, onProgress);
+    merged = merged.concat(rows);
+  }
+  return merged;
+}
+
+/**
+ * @param {Record<string, Uint8Array>} entries
+ * @param {(progress: { phase: string, percent?: number }) => void} [onProgress]
+ * @returns {Promise<{ playActivityRows: Record<string, string>[], dailyTrackRows: Record<string, string>[] | null, sourcePaths: { playActivity: string, dailyTracks: string | null } }>}
+ */
+export async function parseZipEntries(entries, onProgress) {
+  const paths = findAllPlayActivityPaths(entries);
+  if (paths.length === 0) {
+    throw new Error(
+      'No "Apple Music Play Activity.csv" found. Upload that file directly, or include the full Apple Media Services ZIP.',
+    );
+  }
+
+  const firstCsv = decodeUtf8(entries[paths[0]]);
+  const headerLine = firstCsv.split(/\r?\n/)[0] ?? '';
+  const headers = Papa.parse(headerLine, { header: false }).data[0] ?? [];
+  const headerValidation = validatePlayActivityHeaders(headers);
+  if (!headerValidation.ok) {
+    throw new Error(headerValidation.message);
+  }
+
+  const playActivityRows = await parseMergedPlayActivityFromZip(entries, paths, onProgress);
+  const rowValidation = validatePlayActivityRows(playActivityRows);
+  if (!rowValidation.ok) {
+    throw new Error(rowValidation.message);
+  }
+
+  let dailyTrackRows = null;
+  let dailyPath = null;
+  const dailyFound = findDailyTracksInZip(entries);
+  if (dailyFound) {
+    const dailyText = decodeUtf8(dailyFound.data);
+    const dailyHeaderLine = dailyText.split(/\r?\n/)[0] ?? '';
+    const dailyHeaders = Papa.parse(dailyHeaderLine, { header: false }).data[0] ?? [];
+    const dailyHeaderVal = validateDailyTracksRowsFromHeaders(
+      dailyHeaders.map((h) => String(h ?? '').trim()),
+    );
+    if (dailyHeaderVal.ok) {
+      dailyTrackRows = await parseDailyTracksCsv(dailyText, onProgress);
+      const dailyRowVal = validateDailyTracksRows(dailyTrackRows);
+      if (!dailyRowVal.ok) {
+        dailyTrackRows = null;
+      } else {
+        dailyPath = dailyFound.path;
+      }
+    }
+  }
+
+  return {
+    playActivityRows,
+    dailyTrackRows,
+    sourcePaths: {
+      playActivity: paths.join(' | '),
+      dailyTracks: dailyPath,
+    },
+  };
+}
+
+/**
  * @param {File} file
  * @param {(progress: { phase: string, percent?: number }) => void} [onProgress]
- * @returns {Promise<{ rows: Record<string, string>[], sourcePath: string }>}
+ * @returns {Promise<{ playActivityRows: Record<string, string>[], dailyTrackRows: Record<string, string>[] | null, sourcePaths: { playActivity: string, dailyTracks: string | null } }>}
  */
 async function loadCsvFile(file, onProgress) {
   onProgress?.({ phase: 'reading', percent: 0 });
@@ -121,19 +239,23 @@ async function loadCsvFile(file, onProgress) {
     throw new Error(headerValidation.message);
   }
 
-  const rows = await parsePlayActivityCsv(text, onProgress);
-  const rowValidation = validatePlayActivityRows(rows);
+  const playActivityRows = await parsePlayActivityCsv(text, onProgress);
+  const rowValidation = validatePlayActivityRows(playActivityRows);
   if (!rowValidation.ok) {
     throw new Error(rowValidation.message);
   }
 
-  return { rows, sourcePath: file.name };
+  return {
+    playActivityRows,
+    dailyTrackRows: null,
+    sourcePaths: { playActivity: file.name, dailyTracks: null },
+  };
 }
 
 /**
  * @param {File} file
  * @param {(progress: { phase: string, percent?: number }) => void} [onProgress]
- * @returns {Promise<{ rows: Record<string, string>[], sourcePath: string }>}
+ * @returns {Promise<{ playActivityRows: Record<string, string>[], dailyTrackRows: Record<string, string>[] | null, sourcePaths: { playActivity: string, dailyTracks: string | null } }>}
  */
 async function loadZipFile(file, onProgress) {
   onProgress?.({ phase: 'unzipping', percent: 0 });
@@ -146,36 +268,15 @@ async function loadZipFile(file, onProgress) {
   }
   onProgress?.({ phase: 'unzipping', percent: 100 });
 
-  const found = findPlayActivityInZip(entries);
-  if (!found) {
-    throw new Error(
-      `No "Apple Music Play Activity.csv" found inside "${file.name}". ` +
-        'Upload that file directly, or include the full Apple Media Services ZIP.',
-    );
-  }
-
-  const csvText = decodeUtf8(found.data);
-  const headerLine = csvText.split(/\r?\n/)[0] ?? '';
-  const headers = Papa.parse(headerLine, { header: false }).data[0] ?? [];
-  const headerValidation = validatePlayActivityHeaders(headers);
-  if (!headerValidation.ok) {
-    throw new Error(headerValidation.message);
-  }
-
-  const rows = await parsePlayActivityCsv(csvText, onProgress);
-  const rowValidation = validatePlayActivityRows(rows);
-  if (!rowValidation.ok) {
-    throw new Error(rowValidation.message);
-  }
-
-  return { rows, sourcePath: found.path };
+  const result = await parseZipEntries(entries, onProgress);
+  return result;
 }
 
 /**
  * Load one or more ZIP parts / CSV files.
  * @param {File | File[]} input
  * @param {(progress: { phase: string, percent?: number }) => void} [onProgress]
- * @returns {Promise<{ rows: Record<string, string>[], sourcePath: string }>}
+ * @returns {Promise<{ playActivityRows: Record<string, string>[], dailyTrackRows: Record<string, string>[] | null, sourcePaths: { playActivity: string, dailyTracks: string | null } }>}
  */
 export async function loadExport(input, onProgress) {
   const files = Array.isArray(input) ? input : [input];
@@ -212,20 +313,7 @@ export async function loadExport(input, onProgress) {
       Object.assign(merged, entries);
       onProgress?.({ phase: 'unzipping', percent: Math.round(((i + 1) / zipFiles.length) * 100) });
     }
-    const found = findPlayActivityInZip(merged);
-    if (!found) {
-      throw new Error(
-        'No "Apple Music Play Activity.csv" found across the uploaded ZIP parts. ' +
-          'Upload the CSV from Apple Music Activity folder directly.',
-      );
-    }
-    const csvText = decodeUtf8(found.data);
-    const rows = await parsePlayActivityCsv(csvText, onProgress);
-    const rowValidation = validatePlayActivityRows(rows);
-    if (!rowValidation.ok) {
-      throw new Error(rowValidation.message);
-    }
-    return { rows, sourcePath: found.path };
+    return parseZipEntries(merged, onProgress);
   }
 
   return loadZipFile(zipFiles[0], onProgress);
@@ -248,3 +336,5 @@ export function filterRowsByStartDate(rows, filterDate) {
       (row['Event Start Timestamp'] && row['Event Start Timestamp'] >= cutoff),
   );
 }
+
+export { filterDailyTracksByStartDate } from './parseDailyTracksCsv.js';

--- a/src/data/parseDailyTracksCsv.js
+++ b/src/data/parseDailyTracksCsv.js
@@ -1,0 +1,134 @@
+import Papa from 'papaparse';
+import {
+  DAILY_CANONICAL,
+  resolveDailyHeader,
+  validateDailyTracksHeaders,
+} from './schema/playHistoryDailyTracks.js';
+import { parseTrackDescription } from './parseTrackDescription.js';
+
+/**
+ * @param {string} [s]
+ * @returns {string | null} YYYY-MM-DD or null
+ */
+export function datePlayedToIsoDate(s) {
+  if (!s?.trim()) {
+    return null;
+  }
+  const trimmed = s.trim();
+  if (/^\d{8}$/.test(trimmed)) {
+    return `${trimmed.slice(0, 4)}-${trimmed.slice(4, 6)}-${trimmed.slice(6, 8)}`;
+  }
+  if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) {
+    return trimmed.slice(0, 10);
+  }
+  const t = Date.parse(trimmed);
+  if (Number.isNaN(t)) {
+    return null;
+  }
+  return new Date(t).toISOString().slice(0, 10);
+}
+
+/**
+ * @param {Record<string, string>[]} rows
+ * @param {string} filterDate YYYY-MM-DD
+ * @returns {Record<string, string>[]}
+ */
+export function filterDailyTracksByStartDate(rows, filterDate) {
+  if (!filterDate || filterDate.length < 2 || !rows?.length) {
+    return rows ?? [];
+  }
+  return rows.filter((row) => {
+    const iso = datePlayedToIsoDate(row['Date Played']);
+    if (!iso) {
+      return true;
+    }
+    return iso >= filterDate;
+  });
+}
+
+/**
+ * @param {Record<string, string>} raw
+ * @returns {Record<string, string>}
+ */
+export function normalizeDailyTrackRow(raw) {
+  const out = { ...raw };
+  for (const [key, value] of Object.entries(raw)) {
+    const canonical = resolveDailyHeader(key);
+    if (canonical && canonical !== key) {
+      out[canonical] = value;
+    }
+  }
+  const desc = out[DAILY_CANONICAL.trackDescription]?.trim() ?? '';
+  const { artist, song, album } = parseTrackDescription(desc);
+  const albumCol = out[DAILY_CANONICAL.albumName]?.trim();
+  out[DAILY_CANONICAL.songName] = song || desc;
+  out[DAILY_CANONICAL.artistName] = artist;
+  if (!albumCol && album) {
+    out[DAILY_CANONICAL.albumName] = album;
+  }
+  return out;
+}
+
+/**
+ * @param {Record<string, string>[]} rows
+ * @returns {Record<string, string>[]}
+ */
+export function normalizeDailyTrackRows(rows) {
+  return rows.map(normalizeDailyTrackRow);
+}
+
+/**
+ * @param {string} csvText
+ * @param {(progress: { phase: string, percent?: number }) => void} [onProgress]
+ * @returns {Promise<Record<string, string>[]>}
+ */
+export function parseDailyTracksCsv(csvText, onProgress) {
+  onProgress?.({ phase: 'parsing', percent: 0 });
+
+  return new Promise((resolve, reject) => {
+    const rows = [];
+    Papa.parse(csvText, {
+      header: true,
+      skipEmptyLines: true,
+      step(results) {
+        if (results.data) {
+          rows.push(results.data);
+        }
+      },
+      complete() {
+        onProgress?.({ phase: 'parsing', percent: 100 });
+        resolve(normalizeDailyTrackRows(rows));
+      },
+      error(err) {
+        reject(new Error(err.message || 'Failed to parse daily tracks CSV'));
+      },
+    });
+  });
+}
+
+/**
+ * @param {string[]} headers
+ * @returns {{ ok: true } | { ok: false, message: string }}
+ */
+export function validateDailyTracksRowsFromHeaders(headers) {
+  if (!headers || headers.length === 0) {
+    return { ok: false, message: 'The daily tracks file has no column headers.' };
+  }
+  const v = validateDailyTracksHeaders(headers);
+  if (!v.ok) {
+    return { ok: false, message: v.message ?? 'Invalid daily tracks headers.' };
+  }
+  return { ok: true };
+}
+
+/**
+ * @param {Record<string, string>[]} rows
+ * @returns {{ ok: true } | { ok: false, message: string }}
+ */
+export function validateDailyTracksRows(rows) {
+  if (!rows || rows.length === 0) {
+    return { ok: false, message: 'The daily tracks file contains no data rows.' };
+  }
+  const headers = Object.keys(rows[0] ?? {});
+  return validateDailyTracksRowsFromHeaders(headers);
+}

--- a/src/data/parseTrackDescription.js
+++ b/src/data/parseTrackDescription.js
@@ -1,0 +1,23 @@
+/**
+ * Parse Apple's combined "Track Description" from Play History Daily Tracks.
+ * Common shapes: "Artist - Title", "Artist - Album - Title", or plain "Title".
+ * @param {string} raw
+ * @returns {{ artist: string, song: string, album: string }}
+ */
+export function parseTrackDescription(raw) {
+  const s = raw?.trim() ?? '';
+  if (!s) {
+    return { artist: 'Unknown Artist', song: '', album: '' };
+  }
+  const parts = s.split(/\s+-\s+/).map((p) => p.trim()).filter(Boolean);
+  if (parts.length === 1) {
+    return { artist: 'Unknown Artist', song: parts[0], album: '' };
+  }
+  if (parts.length === 2) {
+    return { artist: parts[0], song: parts[1], album: '' };
+  }
+  const artist = parts[0];
+  const song = parts[parts.length - 1];
+  const album = parts.slice(1, -1).join(' - ');
+  return { artist, song, album };
+}

--- a/src/data/schema/playHistoryDailyTracks.js
+++ b/src/data/schema/playHistoryDailyTracks.js
@@ -1,0 +1,67 @@
+/** @typedef {import('./playHistoryDailyTracksTypes.js').DailyTrackRow} DailyTrackRow */
+
+export const DAILY_TRACKS_SCHEMA_VERSION = '2026.2';
+
+/** Canonical names after normalization */
+export const DAILY_CANONICAL = {
+  datePlayed: 'Date Played',
+  playDurationMs: 'Play Duration Milliseconds',
+  trackDescription: 'Track Description',
+  playCount: 'Play Count',
+  songName: 'Song Name',
+  artistName: 'Artist Name',
+  albumName: 'Album Name',
+};
+
+/** Minimum columns required to aggregate plays */
+export const DAILY_REQUIRED_HEADERS = [
+  DAILY_CANONICAL.datePlayed,
+  DAILY_CANONICAL.playDurationMs,
+  DAILY_CANONICAL.trackDescription,
+];
+
+export const DAILY_TRACKS_FILE_NAMES = ['apple music - play history daily tracks.csv'];
+
+export function isDailyTracksPath(path) {
+  const base = path.split(/[/\\]/).pop()?.toLowerCase() ?? '';
+  return DAILY_TRACKS_FILE_NAMES.includes(base);
+}
+
+const FIELD_ALIASES = {
+  'date played': DAILY_CANONICAL.datePlayed,
+  'play duration milliseconds': DAILY_CANONICAL.playDurationMs,
+  'track description': DAILY_CANONICAL.trackDescription,
+  'play count': DAILY_CANONICAL.playCount,
+  'album name': DAILY_CANONICAL.albumName,
+};
+
+/**
+ * @param {string} header
+ * @returns {string | null}
+ */
+export function resolveDailyHeader(header) {
+  if (!header) {
+    return null;
+  }
+  const t = header.trim();
+  if (Object.values(DAILY_CANONICAL).includes(t)) {
+    return t;
+  }
+  return FIELD_ALIASES[t.toLowerCase()] ?? null;
+}
+
+/**
+ * @param {string[]} headers
+ * @returns {{ ok: boolean, message?: string }}
+ */
+export function validateDailyTracksHeaders(headers) {
+  const normalized = new Set(headers.map((h) => resolveDailyHeader(h) || h.trim()));
+  const missing = DAILY_REQUIRED_HEADERS.filter((f) => !normalized.has(f));
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      message: `Apple Music - Play History Daily Tracks.csv is missing columns: ${missing.join(', ')}`,
+    };
+  }
+  return { ok: true };
+}

--- a/src/data/schema/playHistoryDailyTracksTypes.js
+++ b/src/data/schema/playHistoryDailyTracksTypes.js
@@ -1,0 +1,11 @@
+/**
+ * @typedef {Object} DailyTrackRow
+ * @property {string} [Date Played]
+ * @property {string} [Play Duration Milliseconds]
+ * @property {string} [Track Description]
+ * @property {string} [Song Name]
+ * @property {string} [Artist Name]
+ * @property {string} [Album Name]
+ */
+
+export {};

--- a/src/lib/computeTopAsync.js
+++ b/src/lib/computeTopAsync.js
@@ -15,15 +15,31 @@ function getWorker() {
 const SMALL_DATASET_THRESHOLD = 25_000;
 
 /**
+ * Normalize legacy array input vs { playActivityRows, dailyTrackRows }.
+ * @param {Record<string, string>[] | { playActivityRows: Record<string, string>[], dailyTrackRows?: Record<string, string>[] | null }} input
+ */
+function normalizeComputePayload(input) {
+  if (Array.isArray(input)) {
+    return { playActivityRows: input, dailyTrackRows: null };
+  }
+  return {
+    playActivityRows: input.playActivityRows ?? [],
+    dailyTrackRows: input.dailyTrackRows ?? null,
+  };
+}
+
+/**
  * Run calculateTop off the main thread for large datasets.
- * @param {Record<string, string>[]} data
+ * @param {Record<string, string>[] | { playActivityRows: Record<string, string>[], dailyTrackRows?: Record<string, string>[] | null }} input
  * @param {string[]} excludedSongs
  * @returns {Promise<import('../components/Computation.js').default extends never ? never : object>}
  */
-export function computeTopAsync(data, excludedSongs = []) {
-  if (data.length < SMALL_DATASET_THRESHOLD) {
+export function computeTopAsync(input, excludedSongs = []) {
+  const { playActivityRows, dailyTrackRows } = normalizeComputePayload(input);
+
+  if (playActivityRows.length < SMALL_DATASET_THRESHOLD) {
     return new Promise((resolve) => {
-      Computation.calculateTop(data, excludedSongs, resolve);
+      Computation.calculateTop(playActivityRows, excludedSongs, resolve, { dailyTrackRows });
     });
   }
 
@@ -45,6 +61,6 @@ export function computeTopAsync(data, excludedSongs = []) {
     };
 
     w.addEventListener('message', onMessage);
-    w.postMessage({ data, excludedSongs, requestId });
+    w.postMessage({ playActivityRows, dailyTrackRows, excludedSongs, requestId });
   });
 }

--- a/src/workers/computeTop.worker.js
+++ b/src/workers/computeTop.worker.js
@@ -1,12 +1,12 @@
 import Computation from '../components/Computation.js';
 
 self.onmessage = (event) => {
-  const { data, excludedSongs, requestId } = event.data;
+  const { playActivityRows, dailyTrackRows, excludedSongs, requestId } = event.data;
 
   try {
-    Computation.calculateTop(data, excludedSongs ?? [], (results) => {
+    Computation.calculateTop(playActivityRows ?? [], excludedSongs ?? [], (results) => {
       self.postMessage({ type: 'complete', requestId, results });
-    });
+    }, { dailyTrackRows: dailyTrackRows ?? null });
   } catch (err) {
     self.postMessage({
       type: 'error',

--- a/test-data/README.md
+++ b/test-data/README.md
@@ -23,12 +23,14 @@ From the **repository root** (Node 24):
 
 ```bash
 node scripts/inspect-export-headers.mjs test-data/apple-media-services
+node scripts/list-export-zip-contents.mjs test-data/apple-media-services
 node scripts/verify-local-export.mjs test-data/apple-media-services
 ```
 
 Use `test-data` instead of `test-data/apple-media-services` if your ZIPs sit at the top level.
 
 - **inspect-export-headers** — walk directories, print `SCHEMA_VERSION`, validate Play Activity headers.
-- **verify-local-export** — merge ZIP parts, expand nested ZIPs, parse CSV, run `Computation` smoke stats.
+- **list-export-zip-contents** — merge ZIP parts like the app, list expanded paths, peek CSV headers (optional `--count` for row counts).
+- **verify-local-export** — merge ZIP parts, expand nested ZIPs, parse Play Activity and optional Daily Tracks, run `Computation` and print activity-only vs merged totals.
 
 See [docs/apple-export-format.md](../docs/apple-export-format.md) and the main [README](../README.md).


### PR DESCRIPTION
## Problem

Apple’s privacy ZIP contains more than **Play Activity**: **`Apple Music - Play History Daily Tracks.csv`** carries **`Track Description`** (artist/title text) and per-row **`Play Count`**, while **Play Activity** is a noisy event stream (filters, 8s threshold, pause stitching, enrichment changing `Artist Name`). Using only Play Activity made **headline play totals and top lists** drift from what people expect—often compared to **Apple Music Replay**, which is a different product metric anyway.

## What this PR does

**Two-source model (when Daily Tracks is in the ZIP)**

| Source | Used for |
|--------|----------|
| **Play History Daily Tracks** | Total plays (sum of **`Play Count`**), top songs/artists, yearly / “this year” buckets. Parses **`Track Description`** into song + artist; supports **`Date Played`** as `YYYYMMDD` or ISO for bucketing and start-date filter. |
| **Play Activity** | Hour-of-week heatmap, skip / end-reason breakdowns, calendar day & month series (anything that needs event timestamps and offsets). |

**Loader & ZIP behavior**

- **`parseZipEntries`** (exported): merge multi-part ZIPs, expand nested archives, **prefer** paths under `Apple_Media_Services/Apple Music Activity/`, **concatenate** multiple Play Activity CSVs if Apple ever emits more than one.
- **`loadExport`** returns `{ playActivityRows, dailyTrackRows, sourcePaths }`; UI passes both into **`computeTopAsync`** / worker.

**Aggregation fixes (Play Activity path)**

- Sort rows by **`Event End Timestamp`** before aggregation.
- Pause stitching (**`isSamePlay` / `isSamePlayNext`**) no longer requires matching **`Artist Name`** (enrichment was breaking stitch and inflating counts).
- Ignore placeholder listens **`N/A`** with **`Unknown Artist`** everywhere (including Daily Tracks).

**Tooling & docs**

- **`scripts/list-export-zip-contents.mjs`**: manifest expanded ZIP entries; optional **`--count`** for CSV row counts.
- **`scripts/verify-local-export.mjs`**: prints Play-Activity-only vs merged headline totals for local QA.
- **`docs/apple-export-format.md`**, README, roadmap, Cursor rules: describe the split, Replay caveats, and chart vs headline mismatch.

## Caveats (called out in docs)

- **Replay ≠ export**: still possible divergence; Daily Tracks + **`Play Count`** is the closest single-table signal in the GDPR bundle for many accounts.
- **Day/month/hour views** still follow Play Activity semantics, so they may not reconcile to headline totals from Daily Tracks.

## Test plan

- [ ] `npm test` and `npm run build`
- [ ] Browser: upload full **Apple Media Services** ZIP (all parts); confirm load, charts, and that headline totals reflect Daily Tracks when the file is present
- [ ] `node scripts/list-export-zip-contents.mjs <zip-dir> [--count]`
- [ ] `node scripts/verify-local-export.mjs <zip-dir>` and compare printed totals