### PR TITLE
feat: local top-stats export and system light/dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If your export includes **`Apple Music - Play History Daily Tracks.csv`** in the
 3. Upload **Apple Music Play Activity.csv** or the **full Apple Media Services ZIP** (select all parts if Apple split the download). The ZIP may also contain **Play History Daily Tracks**; the app picks it up automatically for headline play counts when present.
 4. Optionally leave **“Resolve missing artists via iTunes Search”** enabled (default) so tracks without an artist in the CSV can be labeled from Apple’s public search API (see [docs/apple-export-format.md](docs/apple-export-format.md)).
 5. Wait for parsing and stats — large exports may take a minute.
+6. After the report appears, use **Export** (JSON / Songs CSV / Artists CSV) to download aggregated top stats. Exports are generated **only in your browser**; nothing is uploaded when you save those files. The app also follows your system **light or dark** appearance automatically.
 
 ## Documentation
 

--- a/docs/apple-export-format.md
+++ b/docs/apple-export-format.md
@@ -95,6 +95,12 @@ The **“Resolve missing artists via iTunes Search”** checkbox in the upload b
 
 Unmatched or failed lookups stay **Unknown Artist**. Results are best-effort (search ambiguity, rate limits). See [play-activity-columns.md](play-activity-columns.md) for why the CSV often lacks a per-track artist.
 
+## Exporting computed stats (in the browser)
+
+After the report loads, the dashboard includes **JSON** and **CSV** export buttons. Files contain **aggregated** top songs and artists (and optional “this year” summaries), reflecting the same exclusions you set in the **All Songs** table. Row lists are capped (currently **500** per list) to keep downloads small.
+
+**Privacy:** Export files are built entirely in your browser from data already in memory — nothing is uploaded when you download them.
+
 ## Tests
 
 Synthetic fixtures live in [`fixtures/play-activity/`](../fixtures/play-activity/) (no real listening data). Run:

--- a/src/App.css
+++ b/src/App.css
@@ -747,7 +747,7 @@
 }
 
 .wrapped {
-  background-color: #e11d48;
+  background-color: var(--color-accent);
   background-image: url("/background.jpg");
   display: block;
   background-size: 50%;
@@ -756,7 +756,7 @@
   width: 700px;
   max-width: 100%;
   border-radius: var(--radius-lg);
-  color: #fff;
+  color: var(--color-on-accent);
   box-shadow: var(--shadow-lg);
 }
 
@@ -820,8 +820,8 @@
   font-family: var(--font-body);
   font-weight: 600;
   font-size: var(--text-sm);
-  color: #fff;
-  background: var(--color-ink);
+  color: var(--color-share-btn-fg);
+  background: var(--color-share-btn-bg);
   border: none;
   border-radius: var(--radius-md);
   padding: var(--space-3) var(--space-5);
@@ -833,7 +833,7 @@
 }
 
 .shareButton button:hover {
-  background: #2d2a35;
+  background: var(--color-share-btn-hover);
   transform: translateY(-1px);
 }
 
@@ -914,7 +914,7 @@
   display: inline-block;
   padding: var(--space-3) var(--space-6);
   background: linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-hover) 100%);
-  color: #fff;
+  color: var(--color-on-accent);
   border-radius: var(--radius-md);
   cursor: pointer;
   font-weight: 600;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useState } from 'react';
+import React, { lazy, Suspense, useState, useEffect } from 'react';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
 
@@ -11,6 +11,25 @@ const Results = lazy(() => import('./components/Results'));
 function App() {
   const [data, setData] = useState([]);
   const [loadError, setLoadError] = useState(null);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') {
+      document.documentElement.setAttribute('data-bs-theme', 'light');
+      return;
+    }
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const apply = () => {
+      const dark = mq.matches;
+      document.documentElement.setAttribute('data-bs-theme', dark ? 'dark' : 'light');
+      const meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) {
+        meta.setAttribute('content', dark ? '#16141a' : '#ebe8e3');
+      }
+    };
+    apply();
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  }, []);
 
   let appToLoad;
 

--- a/src/components/Computation.js
+++ b/src/components/Computation.js
@@ -1,6 +1,7 @@
 // import {timestamp} from 'moment-timezone';
 
 import { UNKNOWN_ARTIST } from '../data/normalizePlayRow.js';
+import { getCssColorVar } from '../lib/chartTheme.js';
 
 function varExists(el) { 
     if (el !== null && typeof el !== "undefined" ) { 
@@ -38,26 +39,35 @@ class Computation {
 
 
     static convetrData(input) {
+        const fillPlay = getCssColorVar('--chart-fill-play', 'rgba(251, 126, 42, 0.18)');
+        const fillSkip = getCssColorVar('--chart-fill-skip', 'rgba(109, 185, 154, 0.18)');
+        const linePlay = getCssColorVar('--chart-line-play', '#fb7e2a');
+        const lineSkip = getCssColorVar('--chart-line-skip', '#6db99a');
+        const pointBg = getCssColorVar('--chart-point-bg', 'rgba(255, 255, 255, 0.95)');
+        const pointBorder = getCssColorVar('--chart-point-border', '#ffffff');
+        const pointHoverBg = getCssColorVar('--chart-point-hover-bg', '#ffffff');
+        const pointHoverBorder = getCssColorVar('--chart-point-hover-border', 'rgba(255, 255, 255, 0.85)');
+
         var data = {
             labels: [],
             datasets: [{
                     label: "Played Hours",
-                    backgroundColor: "rgba(220,220,220,0.2)",
-                    borderColor: "#FB7E2A",
-                    pointBackgroundColor: "rgba(220,220,220,1)",
-                    pointBorderColor: "#fff",
-                    pointHoverBackgroundColor: "#fff",
-                    pointHoverBorderColor: "rgba(220,220,220,1)",
+                    backgroundColor: fillPlay,
+                    borderColor: linePlay,
+                    pointBackgroundColor: pointBg,
+                    pointBorderColor: pointBorder,
+                    pointHoverBackgroundColor: pointHoverBg,
+                    pointHoverBorderColor: pointHoverBorder,
                     data: []
                 },
                 {
                     label: "Skipped Hours",
-                    backgroundColor: "rgba(220,220,220,0.2)",
-                    borderColor: "#BCD2C5",
-                    pointBackgroundColor: "rgba(220,220,220,1)",
-                    pointBorderColor: "#fff",
-                    pointHoverBackgroundColor: "#fff",
-                    pointHoverBorderColor: "rgba(220,220,220,1)",
+                    backgroundColor: fillSkip,
+                    borderColor: lineSkip,
+                    pointBackgroundColor: pointBg,
+                    pointBorderColor: pointBorder,
+                    pointHoverBackgroundColor: pointHoverBg,
+                    pointHoverBorderColor: pointHoverBorder,
                     data: []
                 }
             ]

--- a/src/components/MonthChart.jsx
+++ b/src/components/MonthChart.jsx
@@ -27,8 +27,20 @@ class MonthChart extends Component {
 
     constructor(props) {
         super(props);
+        this._colorSchemeMql =
+            typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+                ? window.matchMedia('(prefers-color-scheme: dark)')
+                : null;
+        this._onColorSchemeChange = () => this.forceUpdate();
     }
 
+    componentDidMount() {
+        this._colorSchemeMql?.addEventListener('change', this._onColorSchemeChange);
+    }
+
+    componentWillUnmount() {
+        this._colorSchemeMql?.removeEventListener('change', this._onColorSchemeChange);
+    }
 
     render() {
 

--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -15,6 +15,12 @@ import TotalsBoxes from './TotalsBoxes';
 import AllSongsTable from './AllSongsTable';
 import TopSongBox from './TopSongBox';
 import Wrapped from './Wrapped';
+import {
+  buildArtistsCsv,
+  buildSongsCsv,
+  buildTopStatsJson,
+  triggerDownload,
+} from '../lib/exportTopStats.js';
 
 class Results extends Component {
   constructor(props) {
@@ -78,6 +84,31 @@ class Results extends Component {
 
   clearExcluded() {
     this.runComputation(this.state.data, []);
+  }
+
+  downloadExportJson() {
+    const json = JSON.stringify(
+      buildTopStatsJson({
+        filteredSongs: this.state.filteredSongs,
+        artists: this.state.artists,
+        totals: this.state.totals,
+        thisYear: this.state.thisYear,
+        excludedSongs: this.state.excludedSongs,
+      }),
+      null,
+      2,
+    );
+    triggerDownload('apple-music-top-stats.json', json, 'application/json;charset=utf-8');
+  }
+
+  downloadSongsCsv() {
+    const csv = buildSongsCsv(this.state.filteredSongs);
+    triggerDownload('apple-music-top-songs.csv', csv, 'text/csv;charset=utf-8');
+  }
+
+  downloadArtistsCsv() {
+    const csv = buildArtistsCsv(this.state.artists);
+    triggerDownload('apple-music-top-artists.csv', csv, 'text/csv;charset=utf-8');
   }
 
   render() {
@@ -199,6 +230,22 @@ class Results extends Component {
     return (
       <div>
         <section className="hero hero--dashboard">
+          <div className="results-export-bar d-flex flex-wrap gap-2 align-items-center justify-content-between mb-3">
+            <p className="small text-body-secondary mb-0">
+              Export computed stats (JSON or CSV). Everything stays in your browser — nothing is uploaded.
+            </p>
+            <div className="btn-group" role="group" aria-label="Export top stats">
+              <button type="button" className="btn btn-outline-secondary btn-sm" onClick={() => this.downloadExportJson()}>
+                JSON
+              </button>
+              <button type="button" className="btn btn-outline-secondary btn-sm" onClick={() => this.downloadSongsCsv()}>
+                Songs CSV
+              </button>
+              <button type="button" className="btn btn-outline-secondary btn-sm" onClick={() => this.downloadArtistsCsv()}>
+                Artists CSV
+              </button>
+            </div>
+          </div>
           {topSongBox}
           <TopYears years={this.state.years} />
           <TotalsBoxes

--- a/src/components/Wrapped.jsx
+++ b/src/components/Wrapped.jsx
@@ -62,7 +62,18 @@ function Wrapped({ year }) {
         <button
           type="button"
           onClick={() => {
-            html2canvas(document.getElementById('annualwrapped')).then((canvas) => {
+            const el = document.getElementById('annualwrapped');
+            if (!el) return;
+            const bg =
+              typeof window !== 'undefined'
+                ? window.getComputedStyle(el).backgroundColor || 'rgb(225, 29, 72)'
+                : 'rgb(225, 29, 72)';
+            html2canvas(el, {
+              scale: 2,
+              backgroundColor: bg,
+              logging: false,
+              useCORS: true,
+            }).then((canvas) => {
               downloadDataUrl(canvas.toDataURL('image/png'), 'mymusic.png');
             });
           }}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,7 @@
 /* Design tokens — Apple Music Analyser (2026 refresh) */
 :root {
+  color-scheme: light dark;
+
   /* Color — warm paper + ink + coral accent (distinct from generic “slate + purple”) */
   --color-bg: #ebe8e3;
   --color-bg-elevated: #f7f5f2;
@@ -76,6 +78,78 @@
   --heatmap-80: #359b91;
   --heatmap-90: #1f9085;
   --heatmap-100: #0d9488;
+
+  /* Month chart (Chart.js reads these via getComputedStyle) */
+  --chart-line-play: #fb7e2a;
+  --chart-line-skip: #6db99a;
+  --chart-fill-play: rgba(251, 126, 42, 0.18);
+  --chart-fill-skip: rgba(109, 185, 154, 0.18);
+  --chart-point-bg: rgba(255, 255, 255, 0.95);
+  --chart-point-border: #ffffff;
+  --chart-point-hover-bg: #ffffff;
+  --chart-point-hover-border: rgba(255, 255, 255, 0.85);
+
+  /* Text on strong brand / gradient buttons */
+  --color-on-accent: #ffffff;
+  --color-share-btn-bg: #14121a;
+  --color-share-btn-fg: #ffffff;
+  --color-share-btn-hover: #2d2a35;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #16141a;
+    --color-bg-elevated: #1e1c24;
+    --color-surface: #26232c;
+    --color-surface-muted: #201e26;
+    --color-ink: #f4f1f8;
+    --color-ink-muted: #a39aad;
+    --color-ink-faint: #756d82;
+    --color-border: rgba(244, 241, 248, 0.1);
+    --color-border-strong: rgba(244, 241, 248, 0.16);
+    --color-accent: #fb7185;
+    --color-accent-hover: #f43f5e;
+    --color-accent-soft: rgba(251, 113, 133, 0.14);
+    --color-teal: #2dd4bf;
+    --color-teal-soft: rgba(45, 212, 191, 0.12);
+    --color-danger-bg: #3b121c;
+    --color-danger-border: #881337;
+    --color-danger-text: #fecdd3;
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
+    --shadow-md: 0 4px 14px rgba(0, 0, 0, 0.45), 0 1px 3px rgba(0, 0, 0, 0.35);
+    --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.55), 0 2px 8px rgba(0, 0, 0, 0.4);
+    --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+    --focus-ring: 0 0 0 2px var(--color-bg-elevated), 0 0 0 4px var(--color-accent);
+
+    --heatmap-empty: #2a2730;
+    --heatmap-0: #2a2730;
+    --heatmap-10: #234a45;
+    --heatmap-20: #1f5f56;
+    --heatmap-30: #1b7267;
+    --heatmap-40: #178578;
+    --heatmap-50: #149889;
+    --heatmap-60: #11ab9a;
+    --heatmap-70: #0ebeab;
+    --heatmap-80: #0bd1bc;
+    --heatmap-90: #08e4cd;
+    --heatmap-100: #2dd4bf;
+
+    --chart-line-play: #ffa14a;
+    --chart-line-skip: #7dccb0;
+    --chart-fill-play: rgba(255, 161, 74, 0.2);
+    --chart-fill-skip: rgba(125, 204, 176, 0.2);
+    --chart-point-bg: rgba(38, 35, 44, 0.95);
+    --chart-point-border: #f4f1f8;
+    --chart-point-hover-bg: #f4f1f8;
+    --chart-point-hover-border: rgba(244, 241, 248, 0.85);
+
+    --color-on-accent: #ffffff;
+    --color-share-btn-bg: #3a3644;
+    --color-share-btn-fg: #f4f1f8;
+    --color-share-btn-hover: #4a4558;
+  }
 }
 
 *,
@@ -94,7 +168,7 @@ body {
   background-color: var(--color-bg);
   background-image: radial-gradient(
     ellipse 120% 80% at 50% -20%,
-    rgba(225, 29, 72, 0.06),
+    color-mix(in srgb, var(--color-accent) 14%, transparent),
     transparent 55%
   );
   -webkit-font-smoothing: antialiased;

--- a/src/lib/__tests__/exportTopStats.test.js
+++ b/src/lib/__tests__/exportTopStats.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_EXPORT_ROWS,
+  buildArtistsCsv,
+  buildSongsCsv,
+  buildTopStatsJson,
+} from '../exportTopStats.js';
+
+describe('exportTopStats', () => {
+  const filteredSongs = [
+    {
+      key: "'A' by B",
+      value: { name: 'A', artist: 'B', plays: 3, time: 180000, missedTime: 1000 },
+    },
+    {
+      key: "'C' by D",
+      value: { name: 'C', artist: 'D', plays: 1, time: 60000, missedTime: 0 },
+    },
+  ];
+  const artists = [
+    { key: 'B', value: { plays: 3, time: 180000 } },
+    { key: 'D', value: { plays: 1, time: 60000 } },
+  ];
+  const totals = { totalPlays: 4, totalTime: 240000 };
+
+  it('buildTopStatsJson includes totals, songs, artists, and exclusions', () => {
+    const json = buildTopStatsJson({
+      filteredSongs,
+      artists,
+      totals,
+      thisYear: null,
+      excludedSongs: ["'X' by Y"],
+    });
+    expect(json.totals.totalPlays).toBe(4);
+    expect(json.excludedSongKeys).toEqual(["'X' by Y"]);
+    expect(json.songs).toHaveLength(2);
+    expect(json.songs[0].rank).toBe(1);
+    expect(json.songs[0].name).toBe('A');
+    expect(json.artists[0].name).toBe('B');
+    expect(json.truncated.songs).toBe(false);
+    expect(json.truncated.artists).toBe(false);
+  });
+
+  it('caps lists at MAX_EXPORT_ROWS', () => {
+    const many = Array.from({ length: MAX_EXPORT_ROWS + 10 }, (_, i) => ({
+      key: `k${i}`,
+      value: { name: `n${i}`, artist: 'a', plays: 1, time: 1000, missedTime: 0 },
+    }));
+    const json = buildTopStatsJson({
+      filteredSongs: many,
+      artists: many,
+      totals,
+      thisYear: null,
+      excludedSongs: [],
+    });
+    expect(json.songs).toHaveLength(MAX_EXPORT_ROWS);
+    expect(json.artists).toHaveLength(MAX_EXPORT_ROWS);
+    expect(json.truncated.songs).toBe(true);
+    expect(json.truncated.artists).toBe(true);
+  });
+
+  it('buildSongsCsv and buildArtistsCsv include headers', () => {
+    const songsCsv = buildSongsCsv(filteredSongs);
+    expect(songsCsv.split('\n')[0]).toContain('rank');
+    expect(songsCsv).toContain('A');
+    const artistsCsv = buildArtistsCsv(artists);
+    expect(artistsCsv.split('\n')[0]).toContain('rank');
+    expect(artistsCsv).toContain('B');
+  });
+});

--- a/src/lib/chartTheme.js
+++ b/src/lib/chartTheme.js
@@ -1,0 +1,13 @@
+/**
+ * Read a CSS custom property from :root for Chart.js (browser only).
+ * @param {string} name e.g. '--chart-line-play'
+ * @param {string} fallback
+ * @returns {string}
+ */
+export function getCssColorVar(name, fallback) {
+  if (typeof document === 'undefined') {
+    return fallback;
+  }
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return raw || fallback;
+}

--- a/src/lib/exportTopStats.js
+++ b/src/lib/exportTopStats.js
@@ -1,0 +1,134 @@
+import Papa from 'papaparse';
+import Computation from '../components/Computation.js';
+
+/** Max rows per songs/artists table in CSV and JSON lists (avoids huge downloads). */
+export const MAX_EXPORT_ROWS = 500;
+
+/**
+ * @param {object} params
+ * @param {Array<{ key: string, value: { name?: string, artist?: string, plays: number, time: number, missedTime?: number } }>} params.filteredSongs
+ * @param {Array<{ key: string, value: { plays: number, time: number } }>} params.artists
+ * @param {{ totalPlays: number, totalTime: number }} params.totals
+ * @param {object | null} [params.thisYear]
+ * @param {string[]} params.excludedSongs
+ * @param {number} [params.maxRows]
+ */
+export function buildTopStatsJson({
+  filteredSongs,
+  artists,
+  totals,
+  thisYear = null,
+  excludedSongs,
+  maxRows = MAX_EXPORT_ROWS,
+}) {
+  const cap = (arr) => arr.slice(0, maxRows);
+
+  const songsOut = cap(filteredSongs).map((row, i) => ({
+    rank: i + 1,
+    key: row.key,
+    name: row.value?.name ?? '',
+    artist: row.value?.artist ?? '',
+    plays: row.value?.plays ?? 0,
+    listenedTimeMs: row.value?.time ?? 0,
+    skippedTimeMs: row.value?.missedTime ?? 0,
+    listenedTimeHuman: Computation.convertTime(row.value?.time ?? 0),
+  }));
+
+  const artistsOut = cap(artists).map((row, i) => ({
+    rank: i + 1,
+    name: row.key,
+    plays: row.value?.plays ?? 0,
+    listenedTimeMs: row.value?.time ?? 0,
+    listenedTimeHuman: Computation.convertTime(row.value?.time ?? 0),
+  }));
+
+  let thisYearOut = null;
+  if (thisYear && thisYear.totalPlays > 0) {
+    const ys = Array.isArray(thisYear.songs) ? thisYear.songs : [];
+    const ya = Array.isArray(thisYear.artists) ? thisYear.artists : [];
+    thisYearOut = {
+      year: thisYear.year,
+      totalPlays: thisYear.totalPlays,
+      totalTimeMs: thisYear.totalTime,
+      totalTimeHuman: Computation.convertTime(Number(thisYear.totalTime) || 0),
+      topSongs: cap(ys).map((row, i) => ({
+        rank: i + 1,
+        key: row.key,
+        name: row.value?.name ?? '',
+        artist: row.value?.artist ?? '',
+        plays: row.value?.plays ?? 0,
+        listenedTimeMs: row.value?.time ?? 0,
+        listenedTimeHuman: Computation.convertTime(row.value?.time ?? 0),
+      })),
+      topArtists: cap(ya).map((row, i) => ({
+        rank: i + 1,
+        name: row.key,
+        plays: row.value?.plays ?? 0,
+        listenedTimeMs: row.value?.time ?? 0,
+        listenedTimeHuman: Computation.convertTime(row.value?.time ?? 0),
+      })),
+    };
+  }
+
+  return {
+    exportedAt: new Date().toISOString(),
+    generator: 'Apple Music Analyser',
+    excludedSongKeys: [...excludedSongs],
+    totals: {
+      totalPlays: totals.totalPlays,
+      totalTimeMs: totals.totalTime,
+      totalTimeHuman: Computation.convertTime(totals.totalTime),
+    },
+    songs: songsOut,
+    artists: artistsOut,
+    thisYear: thisYearOut,
+    truncated: {
+      songs: filteredSongs.length > maxRows,
+      artists: artists.length > maxRows,
+      maxRows,
+    },
+  };
+}
+
+export function buildSongsCsv(filteredSongs, maxRows = MAX_EXPORT_ROWS) {
+  const rows = filteredSongs.slice(0, maxRows).map((row, i) => ({
+    rank: i + 1,
+    songKey: row.key,
+    songName: row.value?.name ?? '',
+    artistName: row.value?.artist ?? '',
+    plays: row.value?.plays ?? 0,
+    listenedTimeMs: row.value?.time ?? 0,
+    skippedTimeMs: row.value?.missedTime ?? 0,
+    listenedTimeHuman: Computation.convertTime(row.value?.time ?? 0),
+  }));
+  return Papa.unparse(rows, { header: true });
+}
+
+export function buildArtistsCsv(artists, maxRows = MAX_EXPORT_ROWS) {
+  const rows = artists.slice(0, maxRows).map((row, i) => ({
+    rank: i + 1,
+    artistName: row.key,
+    plays: row.value?.plays ?? 0,
+    listenedTimeMs: row.value?.time ?? 0,
+    listenedTimeHuman: Computation.convertTime(row.value?.time ?? 0),
+  }));
+  return Papa.unparse(rows, { header: true });
+}
+
+/**
+ * @param {string} filename
+ * @param {string} content
+ * @param {string} mimeType
+ */
+export function triggerDownload(filename, content, mimeType) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.rel = 'noopener';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- Adds dashboard export controls for aggregated top stats (JSON plus separate songs and artists CSVs), built entirely in the browser with a 500-row cap per list.
- Implements automatic light/dark theming from `prefers-color-scheme`: design token overrides, Bootstrap `data-bs-theme`, Chart.js colors from CSS variables, and safer Wrapped `html2canvas` capture settings.
- Documents export behavior and adds Vitest coverage for the export helpers.

## Test plan
- [ ] Toggle OS light/dark (or DevTools) and confirm layout, heatmaps, and month chart stay readable.
- [ ] Load a fixture or sample export, run stats, download JSON and both CSVs; spot-check totals and top rows against the UI.
- [ ] Exclude a song in All Songs, re-export, and confirm exports reflect exclusions.
- [ ] If Wrapped appears, generate the share image in light and dark mode and confirm the PNG looks correct.
- [ ] `npm test` and `npm run build` succeed.

Made with [Cursor](https://cursor.com)